### PR TITLE
add stripes and pigment images; increase parts

### DIFF
--- a/.github/workflows/upload.yaml
+++ b/.github/workflows/upload.yaml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: calcit-lang/setup-cr@0.0.3
         with:
-          version: "0.8.54"
+          version: "0.8.55"
 
       - name: "compiles calcit to js"
         run: >

--- a/.github/workflows/upload.yaml
+++ b/.github/workflows/upload.yaml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: calcit-lang/setup-cr@0.0.3
         with:
-          version: "0.8.50"
+          version: "0.8.54"
 
       - name: "compiles calcit to js"
         run: >

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -787,6 +787,22 @@
                               |T $ %{} :Leaf (:at 1713891217583) (:by |rJG4IHzWf) (:text |solublejs/loadImageAsTexture)
                               |b $ %{} :Leaf (:at 1713891217583) (:by |rJG4IHzWf) (:text |device)
                               |h $ %{} :Leaf (:at 1713891217583) (:by |rJG4IHzWf) (:text "|\"https://cos-sh.tiye.me/cos-up/ceec218462f81744323e22dd2d04e94b/pasted-2024-04-17T17:12:29.234Z.png")
+                      |o $ %{} :Expr (:at 1713891216868) (:by |rJG4IHzWf)
+                        :data $ {}
+                          |T $ %{} :Leaf (:at 1716576676907) (:by |rJG4IHzWf) (:text |img-pigment)
+                          |b $ %{} :Expr (:at 1713891217583) (:by |rJG4IHzWf)
+                            :data $ {}
+                              |T $ %{} :Leaf (:at 1713891217583) (:by |rJG4IHzWf) (:text |solublejs/loadImageAsTexture)
+                              |b $ %{} :Leaf (:at 1713891217583) (:by |rJG4IHzWf) (:text |device)
+                              |h $ %{} :Leaf (:at 1716576679983) (:by |rJG4IHzWf) (:text "|\"https://cos-sh.tiye.me/cos-up/4a932a1d8eaf46b4d9d8ec07538e8ee1/pigment.jpg")
+                      |q $ %{} :Expr (:at 1713891216868) (:by |rJG4IHzWf)
+                        :data $ {}
+                          |T $ %{} :Leaf (:at 1716576687847) (:by |rJG4IHzWf) (:text |img-stripes)
+                          |b $ %{} :Expr (:at 1713891217583) (:by |rJG4IHzWf)
+                            :data $ {}
+                              |T $ %{} :Leaf (:at 1713891217583) (:by |rJG4IHzWf) (:text |solublejs/loadImageAsTexture)
+                              |b $ %{} :Leaf (:at 1713891217583) (:by |rJG4IHzWf) (:text |device)
+                              |h $ %{} :Leaf (:at 1716576689869) (:by |rJG4IHzWf) (:text "|\"https://cos-sh.tiye.me/cos-up/d090a685f03af9d31988a2a92b3b8a19/stripes.jpg")
                   |T $ %{} :Expr (:at 1713297765380) (:by |rJG4IHzWf)
                     :data $ {}
                       |D $ %{} :Leaf (:at 1713297784829) (:by |rJG4IHzWf) (:text |js-set)
@@ -835,6 +851,30 @@
                         :data $ {}
                           |T $ %{} :Leaf (:at 1713891224558) (:by |rJG4IHzWf) (:text |js-await)
                           |b $ %{} :Leaf (:at 1713891224558) (:by |rJG4IHzWf) (:text |img-rugs)
+                  |o $ %{} :Expr (:at 1713891224558) (:by |rJG4IHzWf)
+                    :data $ {}
+                      |T $ %{} :Leaf (:at 1713891224558) (:by |rJG4IHzWf) (:text |js-set)
+                      |b $ %{} :Expr (:at 1713891224558) (:by |rJG4IHzWf)
+                        :data $ {}
+                          |T $ %{} :Leaf (:at 1713891224558) (:by |rJG4IHzWf) (:text |.!deref)
+                          |b $ %{} :Leaf (:at 1713891224558) (:by |rJG4IHzWf) (:text |solublejs/atomSharedTextures)
+                      |h $ %{} :Leaf (:at 1716576704541) (:by |rJG4IHzWf) (:text "|\"stripes")
+                      |l $ %{} :Expr (:at 1713891224558) (:by |rJG4IHzWf)
+                        :data $ {}
+                          |T $ %{} :Leaf (:at 1713891224558) (:by |rJG4IHzWf) (:text |js-await)
+                          |b $ %{} :Leaf (:at 1716576701153) (:by |rJG4IHzWf) (:text |img-stripes)
+                  |q $ %{} :Expr (:at 1713891224558) (:by |rJG4IHzWf)
+                    :data $ {}
+                      |T $ %{} :Leaf (:at 1713891224558) (:by |rJG4IHzWf) (:text |js-set)
+                      |b $ %{} :Expr (:at 1713891224558) (:by |rJG4IHzWf)
+                        :data $ {}
+                          |T $ %{} :Leaf (:at 1713891224558) (:by |rJG4IHzWf) (:text |.!deref)
+                          |b $ %{} :Leaf (:at 1713891224558) (:by |rJG4IHzWf) (:text |solublejs/atomSharedTextures)
+                      |h $ %{} :Leaf (:at 1716576716738) (:by |rJG4IHzWf) (:text "|\"pigment")
+                      |l $ %{} :Expr (:at 1713891224558) (:by |rJG4IHzWf)
+                        :data $ {}
+                          |T $ %{} :Leaf (:at 1713891224558) (:by |rJG4IHzWf) (:text |js-await)
+                          |b $ %{} :Leaf (:at 1716576713661) (:by |rJG4IHzWf) (:text |img-pigment)
         |loop-paint! $ %{} :CodeEntry (:doc |)
           :code $ %{} :Expr (:at 1699464116175) (:by |rJG4IHzWf)
             :data $ {}

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -447,6 +447,12 @@
                       |b $ %{} :Leaf (:at 1714883742296) (:by |rJG4IHzWf) (:text |:ripple)
                       |h $ %{} :Leaf (:at 1714883746119) (:by |rJG4IHzWf) (:text "|\"Ripple")
                       |l $ %{} :Leaf (:at 1712938641596) (:by |rJG4IHzWf) (:text |:dark)
+                  |zP $ %{} :Expr (:at 1712938631055) (:by |rJG4IHzWf)
+                    :data $ {}
+                      |T $ %{} :Leaf (:at 1712938631792) (:by |rJG4IHzWf) (:text |::)
+                      |b $ %{} :Leaf (:at 1716718542242) (:by |rJG4IHzWf) (:text |:surround-mirror)
+                      |h $ %{} :Leaf (:at 1716718439892) (:by |rJG4IHzWf) (:text "|\"Surrond Mirror")
+                      |l $ %{} :Leaf (:at 1712938641596) (:by |rJG4IHzWf) (:text |:dark)
       :ns $ %{} :CodeEntry (:doc |)
         :code $ %{} :Expr (:at 1499755354983) (:by nil)
           :data $ {}
@@ -738,6 +744,10 @@
                     :data $ {}
                       |T $ %{} :Leaf (:at 1714883754487) (:by |rJG4IHzWf) (:text |:ripple)
                       |b $ %{} :Leaf (:at 1714883759093) (:by |rJG4IHzWf) (:text |rippleConfigs)
+                  |zD $ %{} :Expr (:at 1716718449053) (:by |rJG4IHzWf)
+                    :data $ {}
+                      |T $ %{} :Leaf (:at 1716718460954) (:by |rJG4IHzWf) (:text |:surround-mirror)
+                      |b $ %{} :Leaf (:at 1716718476124) (:by |rJG4IHzWf) (:text |surroundMirrorConfigs)
         |load-textures! $ %{} :CodeEntry (:doc |)
           :code $ %{} :Expr (:at 1713297574685) (:by |rJG4IHzWf)
             :data $ {}
@@ -1124,6 +1134,7 @@
                               |T $ %{} :Leaf (:at 1533919515671) (:by |rJG4IHzWf) (:text |persist-storage!)
               |yO $ %{} :Expr (:at 1646150039456) (:by |rJG4IHzWf)
                 :data $ {}
+                  |5 $ %{} :Leaf (:at 1716718960690) (:by |rJG4IHzWf) (:text |;)
                   |D $ %{} :Leaf (:at 1646150045747) (:by |rJG4IHzWf) (:text |flipped)
                   |T $ %{} :Leaf (:at 1646150042154) (:by |rJG4IHzWf) (:text |js/setInterval)
                   |b $ %{} :Leaf (:at 1646150175987) (:by |rJG4IHzWf) (:text |60000)
@@ -1493,6 +1504,13 @@
                     |g $ %{} :Expr (:at 1714755629826) (:by |rJG4IHzWf)
                       :data $ {}
                         |T $ %{} :Leaf (:at 1714883764074) (:by |rJG4IHzWf) (:text |rippleConfigs)
+                |zsy $ %{} :Expr (:at 1699464534081) (:by |rJG4IHzWf)
+                  :data $ {}
+                    |T $ %{} :Leaf (:at 1716718499573) (:by |rJG4IHzWf) (:text "|\"../src/apps/surround-mirror")
+                    |a $ %{} :Leaf (:at 1714755628974) (:by |rJG4IHzWf) (:text |:refer)
+                    |g $ %{} :Expr (:at 1714755629826) (:by |rJG4IHzWf)
+                      :data $ {}
+                        |T $ %{} :Leaf (:at 1716718481604) (:by |rJG4IHzWf) (:text |surroundMirrorConfigs)
                 |zt $ %{} :Expr (:at 1709657313552) (:by |rJG4IHzWf)
                   :data $ {}
                     |T $ %{} :Leaf (:at 1709657319126) (:by |rJG4IHzWf) (:text "|\"../src/global")
@@ -1520,7 +1538,7 @@
                             :data $ {}
                               |D $ %{} :Leaf (:at 1711260016101) (:by |rJG4IHzWf) (:text |get-env)
                               |L $ %{} :Leaf (:at 1711260020594) (:by |rJG4IHzWf) (:text "|\"tab")
-                              |T $ %{} :Leaf (:at 1714883775787) (:by |rJG4IHzWf) (:text "|\"ripple")
+                              |T $ %{} :Leaf (:at 1716722001054) (:by |rJG4IHzWf) (:text "|\"surround-mirror")
                   |j $ %{} :Expr (:at 1499755354983) (:by nil)
                     :data $ {}
                       |T $ %{} :Leaf (:at 1499755354983) (:by |root) (:text |:states)

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -453,6 +453,12 @@
                       |b $ %{} :Leaf (:at 1716718542242) (:by |rJG4IHzWf) (:text |:surround-mirror)
                       |h $ %{} :Leaf (:at 1716718439892) (:by |rJG4IHzWf) (:text "|\"Surrond Mirror")
                       |l $ %{} :Leaf (:at 1712938641596) (:by |rJG4IHzWf) (:text |:dark)
+                  |zY $ %{} :Expr (:at 1712938631055) (:by |rJG4IHzWf)
+                    :data $ {}
+                      |T $ %{} :Leaf (:at 1712938631792) (:by |rJG4IHzWf) (:text |::)
+                      |b $ %{} :Leaf (:at 1717259971868) (:by |rJG4IHzWf) (:text |:parallel-mirror)
+                      |h $ %{} :Leaf (:at 1717259976676) (:by |rJG4IHzWf) (:text "|\"Parallel Mirror")
+                      |l $ %{} :Leaf (:at 1712938641596) (:by |rJG4IHzWf) (:text |:dark)
       :ns $ %{} :CodeEntry (:doc |)
         :code $ %{} :Expr (:at 1499755354983) (:by nil)
           :data $ {}
@@ -748,6 +754,10 @@
                     :data $ {}
                       |T $ %{} :Leaf (:at 1716718460954) (:by |rJG4IHzWf) (:text |:surround-mirror)
                       |b $ %{} :Leaf (:at 1716718476124) (:by |rJG4IHzWf) (:text |surroundMirrorConfigs)
+                  |zP $ %{} :Expr (:at 1716718449053) (:by |rJG4IHzWf)
+                    :data $ {}
+                      |T $ %{} :Leaf (:at 1717260004166) (:by |rJG4IHzWf) (:text |:parallel-mirror)
+                      |b $ %{} :Leaf (:at 1717260007417) (:by |rJG4IHzWf) (:text |parallelMirrorConfigs)
         |load-textures! $ %{} :CodeEntry (:doc |)
           :code $ %{} :Expr (:at 1713297574685) (:by |rJG4IHzWf)
             :data $ {}
@@ -1515,6 +1525,13 @@
                     |g $ %{} :Expr (:at 1714755629826) (:by |rJG4IHzWf)
                       :data $ {}
                         |T $ %{} :Leaf (:at 1716718481604) (:by |rJG4IHzWf) (:text |surroundMirrorConfigs)
+                |zsz $ %{} :Expr (:at 1699464534081) (:by |rJG4IHzWf)
+                  :data $ {}
+                    |T $ %{} :Leaf (:at 1717259994310) (:by |rJG4IHzWf) (:text "|\"../src/apps/parallel-mirror")
+                    |a $ %{} :Leaf (:at 1714755628974) (:by |rJG4IHzWf) (:text |:refer)
+                    |g $ %{} :Expr (:at 1714755629826) (:by |rJG4IHzWf)
+                      :data $ {}
+                        |T $ %{} :Leaf (:at 1717259997421) (:by |rJG4IHzWf) (:text |parallelMirrorConfigs)
                 |zt $ %{} :Expr (:at 1709657313552) (:by |rJG4IHzWf)
                   :data $ {}
                     |T $ %{} :Leaf (:at 1709657319126) (:by |rJG4IHzWf) (:text "|\"../src/global")
@@ -1542,7 +1559,7 @@
                             :data $ {}
                               |D $ %{} :Leaf (:at 1711260016101) (:by |rJG4IHzWf) (:text |get-env)
                               |L $ %{} :Leaf (:at 1711260020594) (:by |rJG4IHzWf) (:text "|\"tab")
-                              |T $ %{} :Leaf (:at 1716722001054) (:by |rJG4IHzWf) (:text "|\"surround-mirror")
+                              |T $ %{} :Leaf (:at 1717260156038) (:by |rJG4IHzWf) (:text "|\"parallel-mirror")
                   |j $ %{} :Expr (:at 1499755354983) (:by nil)
                     :data $ {}
                       |T $ %{} :Leaf (:at 1499755354983) (:by |root) (:text |:states)

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -996,8 +996,12 @@
                       |D $ %{} :Leaf (:at 1713891011862) (:by |rJG4IHzWf) (:text |if)
                       |L $ %{} :Expr (:at 1713891012743) (:by |rJG4IHzWf)
                         :data $ {}
-                          |T $ %{} :Leaf (:at 1713891014468) (:by |rJG4IHzWf) (:text |=)
-                          |X $ %{} :Leaf (:at 1713891462583) (:by |rJG4IHzWf) (:text |:image)
+                          |T $ %{} :Leaf (:at 1717002602380) (:by |rJG4IHzWf) (:text |contains?)
+                          |X $ %{} :Expr (:at 1717002636220) (:by |rJG4IHzWf)
+                            :data $ {}
+                              |T $ %{} :Leaf (:at 1717002638887) (:by |rJG4IHzWf) (:text |#{})
+                              |b $ %{} :Leaf (:at 1717002639327) (:by |rJG4IHzWf) (:text |:image)
+                              |h $ %{} :Leaf (:at 1717002642048) (:by |rJG4IHzWf) (:text |:surround-mirror)
                           |b $ %{} :Expr (:at 1713891032978) (:by |rJG4IHzWf)
                             :data $ {}
                               |D $ %{} :Leaf (:at 1713891036901) (:by |rJG4IHzWf) (:text |->)

--- a/compact.cirru
+++ b/compact.cirru
@@ -60,7 +60,7 @@
                 :color :white
         |tabs $ %{} :CodeEntry (:doc |)
           :code $ quote
-            def tabs $ [] (:: :cubic-fire "\"Cubic Fire" :dark) (:: :quaternion-fractal "\"Quaternion Fractal" :dark) (:: :complex-fractal "\"Complex Fractal" :dark) (:: :space-fractal "\"Space Fractal" :dark) (:: :sphere-fractal "\"Sphere Fractal" :dark) (:: :slow-fractal "\"Slow Fractal" :dark) (:: :orbits "\"Orbits" :dark) (:: :stars "\"Stars" :dark) (:: :rings "\"Rings" :dark) (:: :circles "\"Circles" :dark) (:: :kaleidoscope "\"Kaleidoscope" :dark) (:: :image "\"Image" :dark) (:: :clocking "\"Clocking" :dark) (:: :ripple "\"Ripple" :dark)
+            def tabs $ [] (:: :cubic-fire "\"Cubic Fire" :dark) (:: :quaternion-fractal "\"Quaternion Fractal" :dark) (:: :complex-fractal "\"Complex Fractal" :dark) (:: :space-fractal "\"Space Fractal" :dark) (:: :sphere-fractal "\"Sphere Fractal" :dark) (:: :slow-fractal "\"Slow Fractal" :dark) (:: :orbits "\"Orbits" :dark) (:: :stars "\"Stars" :dark) (:: :rings "\"Rings" :dark) (:: :circles "\"Circles" :dark) (:: :kaleidoscope "\"Kaleidoscope" :dark) (:: :image "\"Image" :dark) (:: :clocking "\"Clocking" :dark) (:: :ripple "\"Ripple" :dark) (:: :surround-mirror "\"Surrond Mirror" :dark)
       :ns $ %{} :CodeEntry (:doc |)
         :code $ quote
           ns app.comp.container $ :require (respo-ui.css :as css)
@@ -128,6 +128,7 @@
                 :clocking clockingConfigs
                 :image imageConfigs
                 :ripple rippleConfigs
+                :surround-mirror surroundMirrorConfigs
         |load-textures! $ %{} :CodeEntry (:doc |)
           :code $ quote
             defn load-textures! (device) (hint-fn async)
@@ -179,7 +180,7 @@
               js/window.addEventListener |beforeunload $ fn (event) (persist-storage!)
               js/window.addEventListener |visibilitychange $ fn (event)
                 if (= "\"hidden" js/document.visibilityState) (persist-storage!)
-              flipped js/setInterval 60000 persist-storage!
+              ; flipped js/setInterval 60000 persist-storage!
               ; let
                   raw $ js/localStorage.getItem (:storage-key config/site)
                 when (some? raw)
@@ -242,13 +243,14 @@
             "\"../src/apps/circles" :as circles
             "\"../src/apps/clocking" :refer $ clockingConfigs
             "\"../src/apps/ripple" :refer $ rippleConfigs
+            "\"../src/apps/surround-mirror" :refer $ surroundMirrorConfigs
             "\"../src/global" :refer $ atomSolubleTree
     |app.schema $ %{} :FileEntry
       :defs $ {}
         |store $ %{} :CodeEntry (:doc |)
           :code $ quote
             def store $ {}
-              :tab $ turn-tag (get-env "\"tab" "\"ripple")
+              :tab $ turn-tag (get-env "\"tab" "\"surround-mirror")
               :states $ {}
                 :cursor $ []
       :ns $ %{} :CodeEntry (:doc |)

--- a/compact.cirru
+++ b/compact.cirru
@@ -60,7 +60,7 @@
                 :color :white
         |tabs $ %{} :CodeEntry (:doc |)
           :code $ quote
-            def tabs $ [] (:: :cubic-fire "\"Cubic Fire" :dark) (:: :quaternion-fractal "\"Quaternion Fractal" :dark) (:: :complex-fractal "\"Complex Fractal" :dark) (:: :space-fractal "\"Space Fractal" :dark) (:: :sphere-fractal "\"Sphere Fractal" :dark) (:: :slow-fractal "\"Slow Fractal" :dark) (:: :orbits "\"Orbits" :dark) (:: :stars "\"Stars" :dark) (:: :rings "\"Rings" :dark) (:: :circles "\"Circles" :dark) (:: :kaleidoscope "\"Kaleidoscope" :dark) (:: :image "\"Image" :dark) (:: :clocking "\"Clocking" :dark) (:: :ripple "\"Ripple" :dark) (:: :surround-mirror "\"Surrond Mirror" :dark)
+            def tabs $ [] (:: :cubic-fire "\"Cubic Fire" :dark) (:: :quaternion-fractal "\"Quaternion Fractal" :dark) (:: :complex-fractal "\"Complex Fractal" :dark) (:: :space-fractal "\"Space Fractal" :dark) (:: :sphere-fractal "\"Sphere Fractal" :dark) (:: :slow-fractal "\"Slow Fractal" :dark) (:: :orbits "\"Orbits" :dark) (:: :stars "\"Stars" :dark) (:: :rings "\"Rings" :dark) (:: :circles "\"Circles" :dark) (:: :kaleidoscope "\"Kaleidoscope" :dark) (:: :image "\"Image" :dark) (:: :clocking "\"Clocking" :dark) (:: :ripple "\"Ripple" :dark) (:: :surround-mirror "\"Surrond Mirror" :dark) (:: :parallel-mirror "\"Parallel Mirror" :dark)
       :ns $ %{} :CodeEntry (:doc |)
         :code $ quote
           ns app.comp.container $ :require (respo-ui.css :as css)
@@ -129,6 +129,7 @@
                 :image imageConfigs
                 :ripple rippleConfigs
                 :surround-mirror surroundMirrorConfigs
+                :parallel-mirror parallelMirrorConfigs
         |load-textures! $ %{} :CodeEntry (:doc |)
           :code $ quote
             defn load-textures! (device) (hint-fn async)
@@ -244,13 +245,14 @@
             "\"../src/apps/clocking" :refer $ clockingConfigs
             "\"../src/apps/ripple" :refer $ rippleConfigs
             "\"../src/apps/surround-mirror" :refer $ surroundMirrorConfigs
+            "\"../src/apps/parallel-mirror" :refer $ parallelMirrorConfigs
             "\"../src/global" :refer $ atomSolubleTree
     |app.schema $ %{} :FileEntry
       :defs $ {}
         |store $ %{} :CodeEntry (:doc |)
           :code $ quote
             def store $ {}
-              :tab $ turn-tag (get-env "\"tab" "\"surround-mirror")
+              :tab $ turn-tag (get-env "\"tab" "\"parallel-mirror")
               :states $ {}
                 :cursor $ []
       :ns $ %{} :CodeEntry (:doc |)

--- a/compact.cirru
+++ b/compact.cirru
@@ -136,10 +136,14 @@
                   img-candy $ solublejs/loadImageAsTexture device "\"https://cos-sh.tiye.me/cos-up/c7367e21405d602c5ef5a8c55c35d512/candy.jpeg"
                   img-bubbles $ solublejs/loadImageAsTexture device "\"https://cos-sh.tiye.me/cos-up/20b39957d952bd189e4253369db30335/pasted-2024-04-17T17:00:49.301Z.png"
                   img-rugs $ solublejs/loadImageAsTexture device "\"https://cos-sh.tiye.me/cos-up/ceec218462f81744323e22dd2d04e94b/pasted-2024-04-17T17:12:29.234Z.png"
+                  img-pigment $ solublejs/loadImageAsTexture device "\"https://cos-sh.tiye.me/cos-up/4a932a1d8eaf46b4d9d8ec07538e8ee1/pigment.jpg"
+                  img-stripes $ solublejs/loadImageAsTexture device "\"https://cos-sh.tiye.me/cos-up/d090a685f03af9d31988a2a92b3b8a19/stripes.jpg"
                 js-set (.!deref solublejs/atomSharedTextures) "\"tiye" $ js-await img-tiye
                 js-set (.!deref solublejs/atomSharedTextures) "\"candy" $ js-await img-candy
                 js-set (.!deref solublejs/atomSharedTextures) "\"bubbles" $ js-await img-bubbles
                 js-set (.!deref solublejs/atomSharedTextures) "\"rugs" $ js-await img-rugs
+                js-set (.!deref solublejs/atomSharedTextures) "\"stripes" $ js-await img-stripes
+                js-set (.!deref solublejs/atomSharedTextures) "\"pigment" $ js-await img-pigment
         |loop-paint! $ %{} :CodeEntry (:doc |)
           :code $ quote
             defn loop-paint! () (solublejs/callFramePaint)

--- a/compact.cirru
+++ b/compact.cirru
@@ -162,7 +162,7 @@
               let
                   ret $ js-await (solublejs/initializeContext)
                 if
-                  = :image $ -> @*reel :store :tab
+                  contains? (#{} :image :surround-mirror) (-> @*reel :store :tab)
                   js-await $ load-textures! (.-device ret)
                   do
                     load-textures! $ .-device ret

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "prepare": "yarn compile"
   },
   "devDependencies": {
-    "@calcit/procs": "^0.8.54",
+    "@calcit/procs": "^0.8.55",
     "@types/node": "^20.12.12",
     "@webgpu/types": "^0.1.40",
     "bottom-tip": "^0.1.5",

--- a/package.json
+++ b/package.json
@@ -8,13 +8,13 @@
     "prepare": "yarn compile"
   },
   "devDependencies": {
-    "@calcit/procs": "^0.8.50",
-    "@types/node": "^20.12.7",
+    "@calcit/procs": "^0.8.54",
+    "@types/node": "^20.12.12",
     "@webgpu/types": "^0.1.40",
     "bottom-tip": "^0.1.5",
     "prettier": "^3.2.5",
     "typescript": "^5.4.5",
-    "vite": "^5.2.8",
+    "vite": "^5.2.11",
     "vite-plugin-glsl": "^1.3.0"
   },
   "dependencies": {

--- a/shaders/soluble-math.wgsl
+++ b/shaders/soluble-math.wgsl
@@ -50,9 +50,9 @@ fn is_outside_line(p: vec2f, p1: vec2f, p2: vec2f) -> bool {
 /// axis is luckily a unit vector
 fn rotate_vec3(v: vec3<f32>, center: vec3<f32>, axis: vec3<f32>, angle: f32) -> vec3<f32> {
   let a = v - center;
-  let a_along_axis = dot(a, axis);
+  let a_along_axis = dot(a, normalize(axis)) * axis;
   let a_perp = a - a_along_axis;
   let a_next = a_perp * cos(angle) + normalize(cross(axis, a_perp)) * length(a_perp) * sin(angle) + a_along_axis;
-  return a_next;
+  return a_next + center;
   // return v;
 }

--- a/shaders/soluble-math.wgsl
+++ b/shaders/soluble-math.wgsl
@@ -54,4 +54,5 @@ fn rotate_vec3(v: vec3<f32>, center: vec3<f32>, axis: vec3<f32>, angle: f32) -> 
   let a_perp = a - a_along_axis;
   let a_next = a_perp * cos(angle) + normalize(cross(axis, a_perp)) * length(a_perp) * sin(angle) + a_along_axis;
   return a_next;
+  // return v;
 }

--- a/shaders/soluble-math.wgsl
+++ b/shaders/soluble-math.wgsl
@@ -46,3 +46,12 @@ fn is_outside_line(p: vec2f, p1: vec2f, p2: vec2f) -> bool {
   let l_sq = length_square(perp);
   return product(p, conjugate(perp)).x > l_sq;
 }
+
+/// axis is luckily a unit vector
+fn rotate_vec3(v: vec3<f32>, center: vec3<f32>, axis: vec3<f32>, angle: f32) -> vec3<f32> {
+  let a = v - center;
+  let a_along_axis = dot(a, axis);
+  let a_perp = a - a_along_axis;
+  let a_next = a_perp * cos(angle) + normalize(cross(axis, a_perp)) * length(a_perp) * sin(angle) + a_along_axis;
+  return a_next;
+}

--- a/src/app.mts
+++ b/src/app.mts
@@ -12,6 +12,7 @@ import {} from "./apps/stars.mjs";
 import {} from "./apps/rings.mjs";
 import {} from "./apps/circles.mjs";
 import { rippleConfigs } from "./apps/ripple.mjs";
+import {} from "./apps/surround-mirror.mjs";
 
 // const appConfigs = cubicFireConfigs;
 // const appConfigs = quaternionFractalConfigs;

--- a/src/app.mts
+++ b/src/app.mts
@@ -13,6 +13,7 @@ import {} from "./apps/rings.mjs";
 import {} from "./apps/circles.mjs";
 import { rippleConfigs } from "./apps/ripple.mjs";
 import {} from "./apps/surround-mirror.mjs";
+import {} from "./apps/parallel-mirror.mjs";
 
 // const appConfigs = cubicFireConfigs;
 // const appConfigs = quaternionFractalConfigs;

--- a/src/apps/cubic-fire.wgsl
+++ b/src/apps/cubic-fire.wgsl
@@ -166,7 +166,8 @@ fn fragment_main(vx_out: VertexOut) -> @location(0) vec4<f32> {
       let n = cross(b - a, ray_unit);
 
       let n0 = normalize(n);
-      let d_min = abs(dot(n0, a));
+      // let d_min = abs(dot(n0, a));
+      let d_min = min(abs(dot(n0, a)), abs(dot(n0, b)));
 
       if d_min > 8.0 {
         // too far from ray, contribute no light

--- a/src/apps/image.mts
+++ b/src/apps/image.mts
@@ -43,6 +43,6 @@ export const imageConfigs: SolubleApp = {
     return [store.disableLens, store.radius];
   },
   getTextures: (obj) => {
-    return [obj["tiye"], obj["candy"], obj["bubbles"], obj["rugs"]];
+    return [obj["tiye"], obj["candy"], obj["bubbles"], obj["rugs"], obj["pigment"], obj["stripes"]];
   },
 };

--- a/src/apps/image.wgsl
+++ b/src/apps/image.wgsl
@@ -34,6 +34,8 @@ struct BaseCell {
 @group(2) @binding(2) var image2 : texture_2d<f32>;
 @group(2) @binding(3) var image_bubbles : texture_2d<f32>;
 @group(2) @binding(4) var image_rugs : texture_2d<f32>;
+@group(2) @binding(5) var image_pigment : texture_2d<f32>;
+@group(2) @binding(6) var image_stripes : texture_2d<f32>;
 
 @compute @workgroup_size(8, 8, 1)
 fn compute_main(@builtin(global_invocation_id) global_id: vec3u) {}
@@ -74,7 +76,8 @@ fn fragment_main(vx_out: VertexOut) -> @location(0) vec4<f32> {
 
     // divide circle by 6 segments
   // let parts = 2.286;
-  let parts = 2.333;
+  // let parts = 2.333;
+  let parts = 2. + 1. / 4.;
 
     // radius of the circle containing the shape
   let radius = 800.;
@@ -144,11 +147,15 @@ fn fragment_main(vx_out: VertexOut) -> @location(0) vec4<f32> {
   let pixel2 = textureSample(image2, mySampler, small_coord - vec2f(1., 1.));
   let pixel3 = textureSample(image_bubbles, mySampler, small_coord - vec2f(1., 0.));
   let pixel4 = textureSample(image_rugs, mySampler, small_coord - vec2f(0., 1.));
+  let pixel5 = textureSample(image_pigment, mySampler, small_coord - vec2f(2., 0.));
+  let pixel6 = textureSample(image_stripes, mySampler, small_coord - vec2f(2., 1.));
 
   let inside_image = small_coord.x > 0.0 && small_coord.y > 0. && small_coord.x < 1. && small_coord.y < 1.;
   let inside_image2 = small_coord.x > 1.0 && small_coord.y > 1. && small_coord.x < 2. && small_coord.y < 2.;
   let inside_image3 = small_coord.x > 1.0 && small_coord.y > 0. && small_coord.x < 2. && small_coord.y < 1.;
   let inside_image4 = small_coord.x > 0.0 && small_coord.y > 1. && small_coord.x < 1. && small_coord.y < 2.;
+  let inside_image5 = small_coord.x > 2.0 && small_coord.y > 0. && small_coord.x < 3. && small_coord.y < 1.;
+  let inside_image6 = small_coord.x > 2.0 && small_coord.y > 1. && small_coord.x < 3. && small_coord.y < 2.;
 
   if disableLens {
     if inside_image {
@@ -159,6 +166,10 @@ fn fragment_main(vx_out: VertexOut) -> @location(0) vec4<f32> {
       return pixel3 * opacity;
     } else if inside_image4 {
       return pixel4 * opacity;
+    } else if inside_image5 {
+      return pixel5 * opacity;
+    } else if inside_image6 {
+      return pixel6 * opacity;
     } else {
       return  vec4(0.2, 0.2, 0.2, 1.0) * opacity;
     }
@@ -172,6 +183,10 @@ fn fragment_main(vx_out: VertexOut) -> @location(0) vec4<f32> {
     return pixel3;
   } else if inside_image4 {
     return pixel4;
+  } else if inside_image5 {
+    return pixel5;
+  } else if inside_image6 {
+    return pixel6;
   } else {
     return vec4(0.0, 0.0, 0.0, 0.0);
   }

--- a/src/apps/kaleidoscope.wgsl
+++ b/src/apps/kaleidoscope.wgsl
@@ -94,7 +94,7 @@ fn fragment_main(vx_out: VertexOut) -> @location(0) vec4<f32> {
 
   let disableLens = params.disableLens > 0.5;
   if length(coord) < radius * 22.0 {
-    for (var i = 0u; i < 6u; i++) {
+    for (var i = 0u; i < 18u; i++) {
       let point_angle = atan2(coord.y, coord.x);
       let at_part = floor(point_angle / unit);
       let p1 = vec2(cos(at_part * unit), sin(at_part * unit)) * radius;

--- a/src/apps/parallel-mirror.mts
+++ b/src/apps/parallel-mirror.mts
@@ -1,0 +1,60 @@
+import { createGlobalPointsBuffer } from "../index.mjs";
+
+import mirrors from "./parallel-mirror.wgsl?raw";
+import { Number2, Number4, rand, randBalance, randBetween, range } from "../math.mjs";
+import { type ButtonEvents } from "../control.mjs";
+import { SolubleApp } from "../primes.mjs";
+import { BaseCellParams } from "../paint.mjs";
+
+let store = {
+  disableLens: 0, // or 1
+  radius: 0.98,
+  startedAt: performance.now(),
+};
+
+type Cell = {
+  position: Number4;
+  velocity: Number4;
+};
+
+let makeCell = (a: Number2, b: Number2) => {
+  let base = 20;
+  return { position: [a[0] * base, a[1] * base, 0, 0] as Number4, velocity: [b[0] * base, b[1] * base, 0, 0] as Number4 } as Cell;
+};
+
+let createAwl = () => {
+  return [
+    // V
+    makeCell([-5, 2], [-3, -2]),
+    makeCell([-3, -2], [-1, 2]),
+    // u
+    makeCell([-1, 0], [-1, -1]),
+    makeCell([-1, -1], [-0.5, -2]),
+    makeCell([-0.5, -2], [1, -2]),
+    makeCell([1, -2], [1, 0]),
+    // e
+    makeCell([2, -1], [4, -1]),
+    makeCell([4, -1], [3.5, 0]),
+    makeCell([3.5, 0], [2.5, 0]),
+    makeCell([2.5, 0], [2, -1]),
+    makeCell([2, -1], [2.5, -2]),
+    makeCell([2.5, -2], [3.5, -2]),
+  ] as Cell[];
+};
+
+export const parallelMirrorConfigs: SolubleApp = {
+  initPointsBuffer: () => {
+    let items = createAwl();
+
+    createGlobalPointsBuffer(items.length, (idx) => items[idx]);
+  },
+  useCompute: false,
+  renderShader: mirrors,
+  // onButtonEvent: (events: ButtonEvents) => { },
+  getParams: () => {
+    return [performance.now() - store.startedAt];
+  },
+  getTextures: (obj) => {
+    return [obj["bubbles"]].filter(Boolean);
+  },
+};

--- a/src/apps/parallel-mirror.wgsl
+++ b/src/apps/parallel-mirror.wgsl
@@ -15,18 +15,13 @@ struct Params {
 @group(0) @binding(1) var<uniform> params: Params;
 
 
-
 struct BaseCell {
   a: vec4<f32>,
   b: vec4<f32>,
- c: vec4<f32>,
 };
 
 @group(1) @binding(0) var<storage, read_write> base_points: array<BaseCell>;
 
-
-@group(2) @binding(0) var mySampler : sampler;
-@group(2) @binding(1) var myTexture : texture_2d<f32>;
 
 @compute @workgroup_size(8, 8, 1)
 fn compute_main(@builtin(global_invocation_id) global_id: vec3u) {
@@ -105,12 +100,6 @@ fn ray_closest_point_to_line(viewer_position: vec3f, ray_unit: vec3f, s: Segment
   };
 }
 
-fn rotate_segment(segment: Segment, center: vec3<f32>, axis: vec3<f32>, angle: f32) -> Segment {
-  let next_start = rotate_vec3(segment.start, center, axis, angle);
-  let next_end = rotate_vec3(segment.end, center, axis, angle);
-  return Segment(next_start, next_end);
-}
-
 fn move_segment(segment: Segment, shifts: vec3f) -> Segment {
   let next_start = segment.start + shifts;
   let next_end = segment.end + shifts;
@@ -186,8 +175,7 @@ fn vertex_main(
 }
 
 /// maximum number of reflections
-const max_relect_times = 20u;
-
+const max_relect_times = 8u;
 
 @fragment
 fn fragment_main(vx_out: VertexOut) -> @location(0) vec4<f32> {
@@ -203,29 +191,25 @@ fn fragment_main(vx_out: VertexOut) -> @location(0) vec4<f32> {
 
   var total_color = vec4<f32>(0.2, 0.0, 0.3, 1.0);
 
-  let angle = params.time * 0.0008;
+  let shift_z = 6.0;
 
-  let image_center = vec3f(20. * cos(angle * 0.7), 20. * sin(angle * 0.7), -120.);
-  let image_y = vec3f(0., 1., 0.);
-  let image_x = rotate_vec3(vec3f(1., 0., 0.), vec3(0., 0., 0.), image_y, angle);
-  let image_z = rotate_vec3(vec3f(0., 0., 1.), vec3(0., 0., 0.), image_y, angle);
-  let image_radius = 40.0; // but rect
+  let m_base = 100.;
+  let m1 = vec3f(m_base * 2., m_base, 0.01);
+  let m2 = vec3f(-m_base * 2., m_base, 0.01);
+  let m3 = vec3f(m_base * 2., -m_base, 0.01);
+  let m4 = vec3f(-m_base * 2., -m_base, 0.01);
 
-  let width = 20.;
-  let shift_z = 50.0;
+  let m5 = vec3f(m_base * 2., m_base, -1.77 * shift_z);
+  let m6 = vec3f(-m_base * 2., m_base, -1.77 * shift_z);
+  let m7 = vec3f(m_base * 2., -m_base, -1.77 * shift_z);
+  let m8 = vec3f(-m_base * 2., -m_base, -1.77 * shift_z);
 
-  let p1 = vec3f(width, .1, -shift_z);
-  let p2 = vec3f(.1, width, -shift_z);
-  let p3 = vec3f(-width, 0.1, -shift_z);
-  let p4 = vec3f(0.1, - width, -shift_z);
-
-  let segments_size = 4u;
-  let scale = 1.;
-  let segments = array<Segment, 4>(
-    Segment(scale * p1, scale * p2),
-    Segment(scale * p2, scale * p3),
-    Segment(scale * p3, scale * p4),
-    Segment(scale * p4, scale * p1),
+  let mirrors_size = 4u;
+  let mirrors = array<MirrorTriangle, 4>(
+    MirrorTriangle(m1, m2, m3),
+    MirrorTriangle(m2, m3, m4),
+    MirrorTriangle(m5, m6, m7),
+    MirrorTriangle(m6, m7, m8),
   );
 
   var current_viewer = uniforms.viewer_position;
@@ -240,10 +224,9 @@ fn fragment_main(vx_out: VertexOut) -> @location(0) vec4<f32> {
     var hit_mirror = false;
     var nearest = RayMirrorHit(false, vec3<f32>(0.0, 0.0, 0.0), 1000000., vec3<f32>(0.0, 0.0, 0.0));
 
-    let size = arrayLength(&base_points);
-    for (var mi = 0u; mi < size; mi = mi + 1u) {
-      let ceil = base_points[mi];
-      let mirror = MirrorTriangle(ceil.a.xyz, ceil.b.xyz, ceil.c.xyz);
+
+    for (var mi = 0u; mi < mirrors_size; mi = mi + 1u) {
+      let mirror = mirrors[mi];
       let hit = try_reflect_ray_with_mirror(current_viewer, current_ray_unit, mirror);
 
       if hit.hit && hit.travel > .01 {
@@ -256,30 +239,16 @@ fn fragment_main(vx_out: VertexOut) -> @location(0) vec4<f32> {
       }
     }
 
-    // let view_to_image = image_center - current_viewer;
-    // if dot(view_to_image, current_ray_unit) > 0. { // backface culling
-    //   let view_to_image_surface_distance = dot(image_z, view_to_image);
-    //   let view_hit_image_length = view_to_image_surface_distance / dot(image_z, current_ray_unit);
-    //   let hit_image_surface = current_viewer + view_hit_image_length * current_ray_unit - image_center;
-    //   let hit_image_surface_x = dot(hit_image_surface, image_x);
-    //   let hit_image_surface_y = dot(hit_image_surface, image_y);
-    //   let image_coord = vec2f(hit_image_surface_x, hit_image_surface_y) / image_radius;
-    //   if abs(image_coord.x) < 1.0 && abs(image_coord.y) < 1.0 {
-    //     if view_hit_image_length < nearest.travel { // image is closer than mirror
-    //       hit_image = true;
-    //       hit_image_at = image_coord * 0.5 + 0.5;
-    //       break;
-    //     }
-    //   }
+    // let t = params.time * 0.0008;
 
-    // }
-
-    let t = params.time * 0.0008;
-
-    for (var i = 0u; i < segments_size; i = i + 1u) {
-      var segment = segments[i];
-      segment = rotate_segment(segment, vec3(0., 0., - shift_z), vec3(0., 1., 0.), t);
-      segment = move_segment(segment, vec3(10. * sin(t * 0.9), 10. * sin(t * 0.7), 10. * sin(t * 0.6)));
+    let s_size = arrayLength(&base_points);
+    for (var i = 0u; i < s_size; i = i + 1u) {
+      var segment = Segment(
+        base_points[i].a.xyz,
+        base_points[i].b.xyz
+      );
+      // segment = rotate_segment(segment, vec3(0., 0., - shift_z), vec3(0., 1., 0.), t);
+      // segment = move_segment(segment, vec3(10. * sin(t * 0.9), 10. * sin(t * 0.7), 10. * sin(t * 0.6)));
       let reach = ray_closest_point_to_line(current_viewer, current_ray_unit, segment);
 
       if !reach.positive_side {
@@ -294,10 +263,10 @@ fn fragment_main(vx_out: VertexOut) -> @location(0) vec4<f32> {
 
       let distance = reach.distance;
       let factor = (0.1 + exp(-traveled));
-      // if distance < 0.2 && reach.positive_side {
-      //   total_color = vec4<f32>(1.0, 0.8, 0.0, 1.0);
-      // }
-      total_color += vec4<f32>(1., 1., 0.02, 0.0) * .1 / pow(0.1 + distance, 2.);
+      if distance < 0.2 && reach.positive_side {
+        return vec4<f32>(1.0, 0.8, 0.0, 1.0);
+      }
+      // total_color += vec4<f32>(1., 1., 0.02, 0.0) * .1 / pow(distance - 0.1, 2.);
     }
 
     if hit_mirror {
@@ -307,14 +276,6 @@ fn fragment_main(vx_out: VertexOut) -> @location(0) vec4<f32> {
     } else {
       break;
     }
-  }
-
-
-
-  let img_pixel = textureSample(myTexture, mySampler, hit_image_at);
-
-  if hit_image {
-    return img_pixel;
   }
 
   return total_color;

--- a/src/apps/surround-mirror.mts
+++ b/src/apps/surround-mirror.mts
@@ -20,6 +20,10 @@ type Cell = {
   arm: Number4;
 };
 
+let makeCell = (a: Number4, b: Number4, c: Number4) => {
+  return { position: a, velocity: b, arm: c } as Cell;
+};
+
 // 4 faces
 let createRegularTetrahedron = () => {
   let a = 200;
@@ -28,59 +32,54 @@ let createRegularTetrahedron = () => {
   let p3: Number4 = [-a, a, -a, 0];
   let p4: Number4 = [a, a, a, 0];
 
-  return [
-    { position: p1, velocity: p2, arm: p3 },
-    { position: p1, velocity: p2, arm: p4 },
-    { position: p1, velocity: p3, arm: p4 },
-    { position: p2, velocity: p3, arm: p4 },
-  ] as Cell[];
+  return [makeCell(p1, p2, p3), makeCell(p1, p2, p4), makeCell(p1, p3, p4), makeCell(p2, p3, p4)] as Cell[];
 };
 
 // 6 faces
 let createCube = () => {
-  let p1 = [-a, -a, a, 0];
-  let p2 = [a, -a, a, 0];
-  let p3 = [a, -a, -a, 0];
-  let p4 = [-a, -a, -a, 0];
-  let p5 = [-a, a, a, 0];
-  let p6 = [a, a, a, 0];
-  let p7 = [a, a, -a, 0];
-  let p8 = [-a, a, -a, 0];
+  let p1: Number4 = [-a, -a, a, 0];
+  let p2: Number4 = [a, -a, a, 0];
+  let p3: Number4 = [a, -a, -a, 0];
+  let p4: Number4 = [-a, -a, -a, 0];
+  let p5: Number4 = [-a, a, a, 0];
+  let p6: Number4 = [a, a, a, 0];
+  let p7: Number4 = [a, a, -a, 0];
+  let p8: Number4 = [-a, a, -a, 0];
 
   return [
-    { position: p1, velocity: p2, arm: p3 },
-    { position: p1, velocity: p3, arm: p4 },
-    { position: p1, velocity: p2, arm: p6 },
-    { position: p1, velocity: p5, arm: p6 },
-    { position: p1, velocity: p8, arm: p4 },
-    { position: p1, velocity: p8, arm: p5 },
-    { position: p2, velocity: p7, arm: p3 },
-    { position: p2, velocity: p7, arm: p6 },
-    { position: p3, velocity: p8, arm: p4 },
-    { position: p3, velocity: p8, arm: p7 },
-    { position: p5, velocity: p7, arm: p6 },
-    { position: p5, velocity: p7, arm: p8 },
+    makeCell(p1, p2, p3),
+    makeCell(p1, p3, p4),
+    makeCell(p1, p2, p6),
+    makeCell(p1, p5, p6),
+    makeCell(p1, p8, p4),
+    makeCell(p1, p8, p5),
+    makeCell(p2, p7, p3),
+    makeCell(p2, p7, p6),
+    makeCell(p3, p8, p4),
+    makeCell(p3, p8, p7),
+    makeCell(p5, p7, p6),
+    makeCell(p5, p7, p8),
   ] as Cell[];
 };
 
 // 8 faces
 let createOctahedron = () => {
-  let p1 = [-a, 0, a, 0];
-  let p2 = [a, 0, a, 0];
-  let p3 = [a, 0, -a, 0];
-  let p4 = [-a, 0, -a, 0];
-  let p5 = [0, a * Math.SQRT2, 0, 0];
-  let p6 = [0, -a * Math.SQRT2, 0, 0];
+  let p1: Number4 = [-a, 0, a, 0];
+  let p2: Number4 = [a, 0, a, 0];
+  let p3: Number4 = [a, 0, -a, 0];
+  let p4: Number4 = [-a, 0, -a, 0];
+  let p5: Number4 = [0, a * Math.SQRT2, 0, 0];
+  let p6: Number4 = [0, -a * Math.SQRT2, 0, 0];
 
   return [
-    { position: p1, velocity: p2, arm: p5 },
-    { position: p2, velocity: p3, arm: p5 },
-    { position: p3, velocity: p4, arm: p5 },
-    { position: p4, velocity: p1, arm: p5 },
-    { position: p1, velocity: p2, arm: p6 },
-    { position: p2, velocity: p3, arm: p6 },
-    { position: p3, velocity: p4, arm: p6 },
-    { position: p4, velocity: p1, arm: p6 },
+    makeCell(p1, p2, p5),
+    makeCell(p2, p3, p5),
+    makeCell(p3, p4, p5),
+    makeCell(p4, p1, p5),
+    makeCell(p1, p2, p6),
+    makeCell(p2, p3, p6),
+    makeCell(p3, p4, p6),
+    makeCell(p4, p1, p6),
   ] as Cell[];
 };
 
@@ -96,8 +95,8 @@ let createCone = () => {
     let p2: Number4 = [r * Math.cos(angleNext), r * Math.sin(angleNext), 0, 0];
     let p3: Number4 = [0, 0, h, 0];
     let p4: Number4 = [0, 0, -0.1, 0];
-    cells.push({ position: p1, velocity: p2, arm: p3 });
-    cells.push({ position: p1, velocity: p2, arm: p4 });
+    cells.push(makeCell(p1, p2, p3));
+    cells.push(makeCell(p1, p2, p4));
   });
 
   return cells;
@@ -112,12 +111,7 @@ let createAngle = () => {
   let p5: Number4 = [ratio * a, -a, a, 0];
   let p6: Number4 = [ratio * a, a, a, 0];
 
-  return [
-    { position: p1, velocity: p2, arm: p3 },
-    { position: p2, velocity: p3, arm: p4 },
-    { position: p1, velocity: p2, arm: p5 },
-    { position: p2, velocity: p5, arm: p6 },
-  ] as Cell[];
+  return [makeCell(p1, p2, p3), makeCell(p2, p3, p4), makeCell(p1, p2, p5), makeCell(p2, p5, p6)] as Cell[];
 };
 
 // 12 faces, 20 vertices, according to https://en.wikipedia.org/wiki/Regular_dodecahedron
@@ -156,99 +150,99 @@ let createRegularDodecahedron = () => {
   return [
     /// 1st
     // 1 9 2
-    { position: p1, velocity: p9, arm: p2 },
+    makeCell(p1, p9, p2),
     // 1 2 12
-    { position: p1, velocity: p2, arm: p12 },
+    makeCell(p1, p2, p12),
     // 2 11 12
-    { position: p2, velocity: p11, arm: p12 },
+    makeCell(p2, p11, p12),
 
     /// 2nd
     // 1 5 15
-    { position: p1, velocity: p5, arm: p15 },
+    makeCell(p1, p5, p15),
     // 1 9 10
-    { position: p1, velocity: p9, arm: p10 },
+    makeCell(p1, p9, p10),
     // 1 5 10
-    { position: p1, velocity: p5, arm: p10 },
+    makeCell(p1, p5, p10),
 
     /// 3rd
     // 9 10 2
-    { position: p9, velocity: p10, arm: p2 },
+    makeCell(p9, p10, p2),
     // 2 6 10
-    { position: p2, velocity: p6, arm: p10 },
+    makeCell(p2, p6, p10),
     // 2 6 17
-    { position: p2, velocity: p6, arm: p17 },
+    makeCell(p2, p6, p17),
 
     /// 4th
     // 2 3 17
-    { position: p2, velocity: p3, arm: p17 },
+    makeCell(p2, p3, p17),
     // 3 17 18
-    { position: p3, velocity: p17, arm: p18 },
+    makeCell(p3, p17, p18),
     // 2 3 11
-    { position: p2, velocity: p3, arm: p11 },
+    makeCell(p2, p3, p11),
 
     /// 5th
     // 3 11 12
-    { position: p3, velocity: p11, arm: p12 },
+    makeCell(p3, p11, p12),
     // 3 4 12
-    { position: p3, velocity: p4, arm: p12 },
+    makeCell(p3, p4, p12),
     // 3 4 13
-    { position: p3, velocity: p4, arm: p13 },
+    makeCell(p3, p4, p13),
 
     /// 6th
     // 1 4 12
-    { position: p1, velocity: p4, arm: p12 },
+    makeCell(p1, p4, p12),
     // 1 4 16
-    { position: p1, velocity: p4, arm: p16 },
+    makeCell(p1, p4, p16),
     // 1 15 16
-    { position: p1, velocity: p15, arm: p16 },
+    makeCell(p1, p15, p16),
 
     /// 7th
     // 7 8 14
-    { position: p7, velocity: p8, arm: p14 },
+    makeCell(p7, p8, p14),
     // 7 8 19
-    { position: p7, velocity: p8, arm: p19 },
+    makeCell(p7, p8, p19),
     // 8 19 20
-    { position: p8, velocity: p19, arm: p20 },
+    makeCell(p8, p19, p20),
 
     /// 8th
     // 8 14 16
-    { position: p8, velocity: p14, arm: p16 },
+    makeCell(p8, p14, p16),
     // 14 16 4
-    { position: p14, velocity: p16, arm: p4 },
+    makeCell(p14, p16, p4),
     // 13 14 4
-    { position: p13, velocity: p14, arm: p4 },
+    makeCell(p13, p14, p4),
 
     /// 9th
     // 13 14 7
-    { position: p13, velocity: p14, arm: p7 },
+    makeCell(p13, p14, p7),
     // 7 13 3
-    { position: p7, velocity: p13, arm: p3 },
+    makeCell(p7, p13, p3),
     // 3 7 18
-    { position: p3, velocity: p7, arm: p18 },
+    makeCell(p3, p7, p18),
 
     /// 10th
     // 6 7 19
-    { position: p6, velocity: p7, arm: p19 },
+    makeCell(p6, p7, p19),
     // 6 7 17
-    { position: p6, velocity: p7, arm: p17 },
+    makeCell(p6, p7, p17),
     // 7 17 18
-    { position: p7, velocity: p17, arm: p18 },
+    makeCell(p7, p17, p18),
 
     /// 11th
     // 6 19 20
-    { position: p6, velocity: p19, arm: p20 },
+    makeCell(p6, p19, p20),
     // 6 10 20
-    { position: p6, velocity: p10, arm: p20 },
+    makeCell(p6, p10, p20),
     // 5 10 20
-    { position: p5, velocity: p10, arm: p20 },
+    makeCell(p5, p10, p20),
 
     /// 12th
     // 5 8 20
-    { position: p5, velocity: p8, arm: p20 },
+    makeCell(p5, p8, p20),
     // 5 8 16
-    { position: p5, velocity: p8, arm: p16 },
+    makeCell(p5, p8, p16),
     // 5 15 16
-    { position: p5, velocity: p15, arm: p16 },
+    makeCell(p5, p15, p16),
   ] as Cell[];
 };
 
@@ -273,41 +267,41 @@ let createRegularIcosahedron = () => {
 
   let a12: Number4 = scaled([-1, 0, 0, 0], a);
   return [
-    { position: a1, velocity: a2, arm: a3 },
-    { position: a1, velocity: a3, arm: a4 },
-    { position: a1, velocity: a4, arm: a5 },
-    { position: a1, velocity: a5, arm: a6 },
-    { position: a1, velocity: a6, arm: a2 },
+    makeCell(a1, a2, a3),
+    makeCell(a1, a3, a4),
+    makeCell(a1, a4, a5),
+    makeCell(a1, a5, a6),
+    makeCell(a1, a6, a2),
 
-    { position: a2, velocity: a3, arm: a8 },
-    { position: a3, velocity: a4, arm: a7 },
-    { position: a4, velocity: a5, arm: a11 },
-    { position: a5, velocity: a6, arm: a10 },
-    { position: a6, velocity: a2, arm: a9 },
+    makeCell(a2, a3, a8),
+    makeCell(a3, a4, a7),
+    makeCell(a4, a5, a11),
+    makeCell(a5, a6, a10),
+    makeCell(a6, a2, a9),
 
-    { position: a7, velocity: a8, arm: a3 },
-    { position: a8, velocity: a9, arm: a2 },
-    { position: a9, velocity: a10, arm: a6 },
-    { position: a10, velocity: a11, arm: a5 },
-    { position: a11, velocity: a7, arm: a4 },
+    makeCell(a7, a8, a3),
+    makeCell(a8, a9, a2),
+    makeCell(a9, a10, a6),
+    makeCell(a10, a11, a5),
+    makeCell(a11, a7, a4),
 
-    { position: a7, velocity: a12, arm: a8 },
-    { position: a8, velocity: a12, arm: a9 },
-    { position: a9, velocity: a12, arm: a10 },
-    { position: a10, velocity: a12, arm: a11 },
-    { position: a11, velocity: a12, arm: a7 },
+    makeCell(a7, a12, a8),
+    makeCell(a8, a12, a9),
+    makeCell(a9, a12, a10),
+    makeCell(a10, a12, a11),
+    makeCell(a11, a12, a7),
   ] as Cell[];
 };
 
 export const surroundMirrorConfigs: SolubleApp = {
   initPointsBuffer: () => {
     // let items = createOctahedron();
-    // let items = createCube();
+    let items = createCube();
     // let items = createCone();
     // let items = createAngle();
     // let items = createRegularIcosahedron();
     // let items = createRegularTetrahedron();
-    let items = createRegularDodecahedron();
+    // let items = createRegularDodecahedron();
 
     createGlobalPointsBuffer(items.length, (idx) => items[idx]);
   },

--- a/src/apps/surround-mirror.mts
+++ b/src/apps/surround-mirror.mts
@@ -1,7 +1,7 @@
 import { createGlobalPointsBuffer } from "../index.mjs";
 
 import mirrors from "./surround-mirror.wgsl";
-import { Number4, rand, randBalance, range } from "../math.mjs";
+import { Number4, rand, randBalance, randBetween, range } from "../math.mjs";
 import { type ButtonEvents } from "../control.mjs";
 import { SolubleApp } from "../primes.mjs";
 import { BaseCellParams } from "../paint.mjs";
@@ -20,6 +20,23 @@ type Cell = {
   arm: Number4;
 };
 
+// 4 faces
+let createRegularTetrahedron = () => {
+  let a = 200;
+  let p1: Number4 = [a, -a, -a, 0];
+  let p2: Number4 = [-a, -a, a, 0];
+  let p3: Number4 = [-a, a, -a, 0];
+  let p4: Number4 = [a, a, a, 0];
+
+  return [
+    { position: p1, velocity: p2, arm: p3 },
+    { position: p1, velocity: p2, arm: p4 },
+    { position: p1, velocity: p3, arm: p4 },
+    { position: p2, velocity: p3, arm: p4 },
+  ] as Cell[];
+};
+
+// 6 faces
 let createCube = () => {
   let p1 = [-a, -a, a, 0];
   let p2 = [a, -a, a, 0];
@@ -46,6 +63,7 @@ let createCube = () => {
   ] as Cell[];
 };
 
+// 8 faces
 let createOctahedron = () => {
   let p1 = [-a, 0, a, 0];
   let p2 = [a, 0, a, 0];
@@ -85,11 +103,79 @@ let createCone = () => {
   return cells;
 };
 
+let createAngle = () => {
+  let ratio = 0.6;
+  let p1: Number4 = [0, -a, -a, 0];
+  let p2: Number4 = [0, a, -a, 0];
+  let p3: Number4 = [-ratio * a, -a, a, 0];
+  let p4: Number4 = [-ratio * a, a, a, 0];
+  let p5: Number4 = [ratio * a, -a, a, 0];
+  let p6: Number4 = [ratio * a, a, a, 0];
+
+  return [
+    { position: p1, velocity: p2, arm: p3 },
+    { position: p2, velocity: p3, arm: p4 },
+    { position: p1, velocity: p2, arm: p5 },
+    { position: p2, velocity: p5, arm: p6 },
+  ] as Cell[];
+};
+
+// 20 faces, thanks to https://math.stackexchange.com/a/2174924/54238
+let createRegularIcosahedron = () => {
+  let sqrt5 = Math.sqrt(5);
+  let scaled = (v: Number4, s: number) => v.map((x) => x * s) as Number4;
+
+  let a1: Number4 = scaled([1, 0, 0, 0], a);
+
+  let a2: Number4 = scaled([1 / sqrt5, 2 / sqrt5, 0, 0], a);
+  let a3: Number4 = scaled([1 / sqrt5, (5 - sqrt5) / 10, Math.sqrt((5 + sqrt5) / 10), 0], a);
+  let a4: Number4 = scaled([1 / sqrt5, (-5 - sqrt5) / 10, Math.sqrt((5 - sqrt5) / 10), 0], a);
+  let a5: Number4 = scaled([1 / sqrt5, (-5 - sqrt5) / 10, -Math.sqrt((5 - sqrt5) / 10), 0], a);
+  let a6: Number4 = scaled([1 / sqrt5, (5 - sqrt5) / 10, -Math.sqrt((5 + sqrt5) / 10), 0], a);
+
+  let a7: Number4 = scaled([-1 / sqrt5, (-5 + sqrt5) / 10, Math.sqrt((5 + sqrt5) / 10), 0], a);
+  let a8: Number4 = scaled([-1 / sqrt5, (5 + sqrt5) / 10, Math.sqrt((5 - sqrt5) / 10), 0], a);
+  let a9: Number4 = scaled([-1 / sqrt5, (5 + sqrt5) / 10, -Math.sqrt((5 - sqrt5) / 10), 0], a);
+  let a10: Number4 = scaled([-1 / sqrt5, (-5 + sqrt5) / 10, -Math.sqrt((5 + sqrt5) / 10), 0], a);
+  let a11: Number4 = scaled([-1 / sqrt5, -2 / sqrt5, 0, 0], a);
+
+  let a12: Number4 = scaled([-1, 0, 0, 0], a);
+  return [
+    { position: a1, velocity: a2, arm: a3 },
+    { position: a1, velocity: a3, arm: a4 },
+    { position: a1, velocity: a4, arm: a5 },
+    { position: a1, velocity: a5, arm: a6 },
+    { position: a1, velocity: a6, arm: a2 },
+
+    { position: a2, velocity: a3, arm: a8 },
+    { position: a3, velocity: a4, arm: a7 },
+    { position: a4, velocity: a5, arm: a11 },
+    { position: a5, velocity: a6, arm: a10 },
+    { position: a6, velocity: a2, arm: a9 },
+
+    { position: a7, velocity: a8, arm: a3 },
+    { position: a8, velocity: a9, arm: a2 },
+    { position: a9, velocity: a10, arm: a6 },
+    { position: a10, velocity: a11, arm: a5 },
+    { position: a11, velocity: a7, arm: a4 },
+
+    { position: a7, velocity: a12, arm: a8 },
+    { position: a8, velocity: a12, arm: a9 },
+    { position: a9, velocity: a12, arm: a10 },
+    { position: a10, velocity: a12, arm: a11 },
+    { position: a11, velocity: a12, arm: a7 },
+  ] as Cell[];
+};
+
 export const surroundMirrorConfigs: SolubleApp = {
   initPointsBuffer: () => {
     // let items = createOctahedron();
     // let items = createCube();
-    let items = createCone();
+    // let items = createCone();
+    // let items = createAngle();
+    // let items = createRegularIcosahedron();
+    let items = createRegularTetrahedron();
+
     createGlobalPointsBuffer(items.length, (idx) => items[idx]);
   },
   useCompute: false,

--- a/src/apps/surround-mirror.mts
+++ b/src/apps/surround-mirror.mts
@@ -299,10 +299,10 @@ export const surroundMirrorConfigs: SolubleApp = {
   initPointsBuffer: () => {
     // let items = createOctahedron();
     // let items = createCube();
-    // let items = createCone();
+    let items = createCone();
     // let items = createAngle();
     // let items = createRegularIcosahedron();
-    let items = createRegularTetrahedron();
+    // let items = createRegularTetrahedron();
     // let items = createRegularDodecahedron();
 
     createGlobalPointsBuffer(items.length, (idx) => items[idx]);
@@ -314,6 +314,6 @@ export const surroundMirrorConfigs: SolubleApp = {
     return [performance.now() - store.startedAt];
   },
   getTextures: (obj) => {
-    return [obj["pigment"]].filter(Boolean);
+    return [obj["bubbles"]].filter(Boolean);
   },
 };

--- a/src/apps/surround-mirror.mts
+++ b/src/apps/surround-mirror.mts
@@ -12,8 +12,6 @@ let store = {
   startedAt: performance.now(),
 };
 
-let a = 400;
-
 type Cell = {
   position: Number4;
   velocity: Number4;
@@ -37,6 +35,7 @@ let createRegularTetrahedron = () => {
 
 // 6 faces
 let createCube = () => {
+  let a = 400;
   let p1: Number4 = [-a, -a, a, 0];
   let p2: Number4 = [a, -a, a, 0];
   let p3: Number4 = [a, -a, -a, 0];
@@ -64,6 +63,7 @@ let createCube = () => {
 
 // 8 faces
 let createOctahedron = () => {
+  let a = 400;
   let p1: Number4 = [-a, 0, a, 0];
   let p2: Number4 = [a, 0, a, 0];
   let p3: Number4 = [a, 0, -a, 0];
@@ -103,6 +103,7 @@ let createCone = () => {
 };
 
 let createAngle = () => {
+  let a = 400;
   let ratio = 0.6;
   let p1: Number4 = [0, -a, -a, 0];
   let p2: Number4 = [0, a, -a, 0];
@@ -248,6 +249,7 @@ let createRegularDodecahedron = () => {
 
 // 20 faces, thanks to https://math.stackexchange.com/a/2174924/54238
 let createRegularIcosahedron = () => {
+  let a = 400;
   let sqrt5 = Math.sqrt(5);
   let scaled = (v: Number4, s: number) => v.map((x) => x * s) as Number4;
 
@@ -312,6 +314,6 @@ export const surroundMirrorConfigs: SolubleApp = {
     return [performance.now() - store.startedAt];
   },
   getTextures: (obj) => {
-    return [obj["pigment"]];
+    return [obj["pigment"]].filter(Boolean);
   },
 };

--- a/src/apps/surround-mirror.mts
+++ b/src/apps/surround-mirror.mts
@@ -104,7 +104,7 @@ let createCone = () => {
 
 let createAwl = () => {
   let a = 40;
-  let d = 200;
+  let d = 160;
   let SQRT_3 = Math.sqrt(3);
   let p0: Number4 = [0, 0, -d, 0];
   let p1: Number4 = [0, a, d, 0];

--- a/src/apps/surround-mirror.mts
+++ b/src/apps/surround-mirror.mts
@@ -9,33 +9,43 @@ import { BaseCellParams } from "../paint.mjs";
 let store = {
   disableLens: 0, // or 1
   radius: 0.98,
+  startedAt: performance.now(),
 };
 
-let createKaleidoscopeBasePoint = (idx: number): BaseCellParams => {
-  let offset = 8000;
-  let position: Number4 = [randBalance(offset), randBalance(offset), randBalance(offset), 1];
-  let arm = [1000, 0, 0, 0] as Number4;
-  let params: Number4 = [idx, rand(20), 2 + rand(2), 0];
-  return { position, arm, params };
+let createOctahedron = () => {
+  let a = 400;
+  let p1 = [-a, 0, a, 0];
+  let p2 = [a, 0, a, 0];
+  let p3 = [a, 0, -a, 0];
+  let p4 = [-a, 0, -a, 0];
+  let p5 = [0, a * Math.SQRT2, 0, 0];
+  let p6 = [0, -a * Math.SQRT2, 0, 0];
+
+  return [
+    { position: p1, velocity: p2, arm: p5 },
+    { position: p2, velocity: p3, arm: p5 },
+    { position: p3, velocity: p4, arm: p5 },
+    { position: p4, velocity: p1, arm: p5 },
+    { position: p1, velocity: p2, arm: p6 },
+    { position: p2, velocity: p3, arm: p6 },
+    { position: p3, velocity: p4, arm: p6 },
+    { position: p4, velocity: p1, arm: p6 },
+  ] as {
+    position: Number4;
+    velocity: Number4;
+    arm: Number4;
+  }[];
 };
 
 export const surroundMirrorConfigs: SolubleApp = {
   initPointsBuffer: () => {
-    createGlobalPointsBuffer(160, createKaleidoscopeBasePoint);
+    let items = createOctahedron();
+    createGlobalPointsBuffer(items.length, (idx) => items[idx]);
   },
   useCompute: false,
   renderShader: mirrors,
-  onButtonEvent: (events: ButtonEvents) => {
-    if (events.face1) {
-      store.disableLens = store.disableLens < 0.5 ? 1 : 0;
-      console.log("face1 tapped", store.disableLens);
-    }
-    if (events.face2) {
-      store.radius = Math.max(0, store.radius - 0.1);
-      console.log("face2 tapped", store.radius);
-    }
-  },
+  // onButtonEvent: (events: ButtonEvents) => { },
   getParams: () => {
-    return [store.disableLens, store.radius];
+    return [performance.now() - store.startedAt];
   },
 };

--- a/src/apps/surround-mirror.mts
+++ b/src/apps/surround-mirror.mts
@@ -1,0 +1,45 @@
+import { createGlobalPointsBuffer } from "../index.mjs";
+
+import mirrors from "./surround-mirror.wgsl";
+import { Number4, rand, randBalance } from "../math.mjs";
+import { type ButtonEvents } from "../control.mjs";
+import { SolubleApp } from "../primes.mjs";
+import { BaseCellParams } from "../paint.mjs";
+
+let store = {
+  disableLens: 0, // or 1
+  radius: 0.98,
+};
+
+let createKaleidoscopeBasePoint = (idx: number): BaseCellParams => {
+  let offset = 8000;
+  let armOffset = 8000;
+  let position: Number4 = [randBalance(offset), randBalance(offset), randBalance(offset), 1];
+  // let arm: Number4 = [randBalance(armOffset), randBalance(armOffset), randBalance(armOffset), 1];
+  // let arm: Number4 = [100, 0, 0, 0];
+  // let arm: Number4 = [randBalance(armOffset), randBalance(armOffset), randBalance(armOffset), 0];
+  let arm = [1000, 0, 0, 0] as Number4;
+  let params: Number4 = [idx, rand(20), 2 + rand(2), 0];
+  return { position, arm, params };
+};
+
+export const surroundMirrorConfigs: SolubleApp = {
+  initPointsBuffer: () => {
+    createGlobalPointsBuffer(160, createKaleidoscopeBasePoint);
+  },
+  useCompute: false,
+  renderShader: mirrors,
+  onButtonEvent: (events: ButtonEvents) => {
+    if (events.face1) {
+      store.disableLens = store.disableLens < 0.5 ? 1 : 0;
+      console.log("face1 tapped", store.disableLens);
+    }
+    if (events.face2) {
+      store.radius = Math.max(0, store.radius - 0.1);
+      console.log("face2 tapped", store.radius);
+    }
+  },
+  getParams: () => {
+    return [store.disableLens, store.radius];
+  },
+};

--- a/src/apps/surround-mirror.mts
+++ b/src/apps/surround-mirror.mts
@@ -123,6 +123,7 @@ let createAngle = () => {
 // 12 faces, 20 vertices, according to https://en.wikipedia.org/wiki/Regular_dodecahedron
 // TODO check each points
 let createRegularDodecahedron = () => {
+  let a = 200;
   let phi = (1 + Math.sqrt(5)) / 2;
   let scaled = (v: Number4, s: number) => v.map((x) => x * s) as Number4;
 
@@ -138,8 +139,8 @@ let createRegularDodecahedron = () => {
 
   let p9: Number4 = scaled([0, -1 / phi, phi, 0], a);
   let p10: Number4 = scaled([0, 1 / phi, phi, 0], a);
-  let p11: Number4 = scaled([1 / phi, 0, -phi, 0], a);
-  let p12: Number4 = scaled([-1 / phi, 0, -phi, 0], a);
+  let p11: Number4 = scaled([1 / phi, -phi, 0, 0], a);
+  let p12: Number4 = scaled([-1 / phi, -phi, 0, 0], a);
 
   let p13: Number4 = scaled([0, -1 / phi, -phi, 0], a);
   let p14: Number4 = scaled([0, 1 / phi, -phi, 0], a);

--- a/src/apps/surround-mirror.mts
+++ b/src/apps/surround-mirror.mts
@@ -1,7 +1,7 @@
 import { createGlobalPointsBuffer } from "../index.mjs";
 
 import mirrors from "./surround-mirror.wgsl";
-import { Number4, rand, randBalance } from "../math.mjs";
+import { Number4, rand, randBalance, range } from "../math.mjs";
 import { type ButtonEvents } from "../control.mjs";
 import { SolubleApp } from "../primes.mjs";
 import { BaseCellParams } from "../paint.mjs";
@@ -13,6 +13,12 @@ let store = {
 };
 
 let a = 400;
+
+type Cell = {
+  position: Number4;
+  velocity: Number4;
+  arm: Number4;
+};
 
 let createCube = () => {
   let p1 = [-a, -a, a, 0];
@@ -37,11 +43,7 @@ let createCube = () => {
     { position: p3, velocity: p8, arm: p7 },
     { position: p5, velocity: p7, arm: p6 },
     { position: p5, velocity: p7, arm: p8 },
-  ] as {
-    position: Number4;
-    velocity: Number4;
-    arm: Number4;
-  }[];
+  ] as Cell[];
 };
 
 let createOctahedron = () => {
@@ -61,17 +63,33 @@ let createOctahedron = () => {
     { position: p2, velocity: p3, arm: p6 },
     { position: p3, velocity: p4, arm: p6 },
     { position: p4, velocity: p1, arm: p6 },
-  ] as {
-    position: Number4;
-    velocity: Number4;
-    arm: Number4;
-  }[];
+  ] as Cell[];
+};
+
+let createCone = () => {
+  let cells: Cell[] = [];
+  let n = 8;
+  range(n).forEach((idx) => {
+    let angle = (idx / n) * 2 * Math.PI;
+    let angleNext = ((idx + 1) / n) * 2 * Math.PI;
+    let r = 400;
+    let h = 400;
+    let p1: Number4 = [r * Math.cos(angle), r * Math.sin(angle), 0, 0];
+    let p2: Number4 = [r * Math.cos(angleNext), r * Math.sin(angleNext), 0, 0];
+    let p3: Number4 = [0, 0, h, 0];
+    let p4: Number4 = [0, 0, -0.1, 0];
+    cells.push({ position: p1, velocity: p2, arm: p3 });
+    cells.push({ position: p1, velocity: p2, arm: p4 });
+  });
+
+  return cells;
 };
 
 export const surroundMirrorConfigs: SolubleApp = {
   initPointsBuffer: () => {
     // let items = createOctahedron();
-    let items = createCube();
+    // let items = createCube();
+    let items = createCone();
     createGlobalPointsBuffer(items.length, (idx) => items[idx]);
   },
   useCompute: false,

--- a/src/apps/surround-mirror.mts
+++ b/src/apps/surround-mirror.mts
@@ -296,11 +296,11 @@ let createRegularIcosahedron = () => {
 export const surroundMirrorConfigs: SolubleApp = {
   initPointsBuffer: () => {
     // let items = createOctahedron();
-    let items = createCube();
+    // let items = createCube();
     // let items = createCone();
     // let items = createAngle();
     // let items = createRegularIcosahedron();
-    // let items = createRegularTetrahedron();
+    let items = createRegularTetrahedron();
     // let items = createRegularDodecahedron();
 
     createGlobalPointsBuffer(items.length, (idx) => items[idx]);
@@ -310,5 +310,8 @@ export const surroundMirrorConfigs: SolubleApp = {
   // onButtonEvent: (events: ButtonEvents) => { },
   getParams: () => {
     return [performance.now() - store.startedAt];
+  },
+  getTextures: (obj) => {
+    return [obj["pigment"]];
   },
 };

--- a/src/apps/surround-mirror.mts
+++ b/src/apps/surround-mirror.mts
@@ -13,11 +13,7 @@ let store = {
 
 let createKaleidoscopeBasePoint = (idx: number): BaseCellParams => {
   let offset = 8000;
-  let armOffset = 8000;
   let position: Number4 = [randBalance(offset), randBalance(offset), randBalance(offset), 1];
-  // let arm: Number4 = [randBalance(armOffset), randBalance(armOffset), randBalance(armOffset), 1];
-  // let arm: Number4 = [100, 0, 0, 0];
-  // let arm: Number4 = [randBalance(armOffset), randBalance(armOffset), randBalance(armOffset), 0];
   let arm = [1000, 0, 0, 0] as Number4;
   let params: Number4 = [idx, rand(20), 2 + rand(2), 0];
   return { position, arm, params };

--- a/src/apps/surround-mirror.mts
+++ b/src/apps/surround-mirror.mts
@@ -120,6 +120,137 @@ let createAngle = () => {
   ] as Cell[];
 };
 
+// 12 faces, 20 vertices, according to https://en.wikipedia.org/wiki/Regular_dodecahedron
+// TODO check each points
+let createRegularDodecahedron = () => {
+  let phi = (1 + Math.sqrt(5)) / 2;
+  let scaled = (v: Number4, s: number) => v.map((x) => x * s) as Number4;
+
+  let p1: Number4 = scaled([-1, -1, 1, 0], a);
+  let p2: Number4 = scaled([1, -1, 1, 0], a);
+  let p3: Number4 = scaled([1, -1, -1, 0], a);
+  let p4: Number4 = scaled([-1, -1, -1, 0], a);
+
+  let p5: Number4 = scaled([-1, 1, 1, 0], a);
+  let p6: Number4 = scaled([1, 1, 1, 0], a);
+  let p7: Number4 = scaled([1, 1, -1, 0], a);
+  let p8: Number4 = scaled([-1, 1, -1, 0], a);
+
+  let p9: Number4 = scaled([0, -1 / phi, phi, 0], a);
+  let p10: Number4 = scaled([0, 1 / phi, phi, 0], a);
+  let p11: Number4 = scaled([1 / phi, 0, -phi, 0], a);
+  let p12: Number4 = scaled([-1 / phi, 0, -phi, 0], a);
+
+  let p13: Number4 = scaled([0, -1 / phi, -phi, 0], a);
+  let p14: Number4 = scaled([0, 1 / phi, -phi, 0], a);
+  let p15: Number4 = scaled([-phi, 0, 1 / phi, 0], a);
+  let p16: Number4 = scaled([-phi, 0, -1 / phi, 0], a);
+
+  let p17: Number4 = scaled([phi, 0, 1 / phi, 0], a);
+  let p18: Number4 = scaled([phi, 0, -1 / phi, 0], a);
+  let p19: Number4 = scaled([1 / phi, phi, 0, 0], a);
+  let p20: Number4 = scaled([-1 / phi, phi, 0, 0], a);
+
+  // 12 faces, but 36 triangles
+  return [
+    /// 1st
+    // 1 9 2
+    { position: p1, velocity: p9, arm: p2 },
+    // 1 2 12
+    { position: p1, velocity: p2, arm: p12 },
+    // 2 11 12
+    { position: p2, velocity: p11, arm: p12 },
+
+    /// 2nd
+    // 1 5 15
+    { position: p1, velocity: p5, arm: p15 },
+    // 1 9 10
+    { position: p1, velocity: p9, arm: p10 },
+    // 1 5 10
+    { position: p1, velocity: p5, arm: p10 },
+
+    /// 3rd
+    // 9 10 2
+    { position: p9, velocity: p10, arm: p2 },
+    // 2 6 10
+    { position: p2, velocity: p6, arm: p10 },
+    // 2 6 17
+    { position: p2, velocity: p6, arm: p17 },
+
+    /// 4th
+    // 2 3 17
+    { position: p2, velocity: p3, arm: p17 },
+    // 3 17 18
+    { position: p3, velocity: p17, arm: p18 },
+    // 2 3 11
+    { position: p2, velocity: p3, arm: p11 },
+
+    /// 5th
+    // 3 11 12
+    { position: p3, velocity: p11, arm: p12 },
+    // 3 4 12
+    { position: p3, velocity: p4, arm: p12 },
+    // 3 4 13
+    { position: p3, velocity: p4, arm: p13 },
+
+    /// 6th
+    // 1 4 12
+    { position: p1, velocity: p4, arm: p12 },
+    // 1 4 16
+    { position: p1, velocity: p4, arm: p16 },
+    // 1 15 16
+    { position: p1, velocity: p15, arm: p16 },
+
+    /// 7th
+    // 7 8 14
+    { position: p7, velocity: p8, arm: p14 },
+    // 7 8 19
+    { position: p7, velocity: p8, arm: p19 },
+    // 8 19 20
+    { position: p8, velocity: p19, arm: p20 },
+
+    /// 8th
+    // 8 14 16
+    { position: p8, velocity: p14, arm: p16 },
+    // 14 16 4
+    { position: p14, velocity: p16, arm: p4 },
+    // 13 14 4
+    { position: p13, velocity: p14, arm: p4 },
+
+    /// 9th
+    // 13 14 7
+    { position: p13, velocity: p14, arm: p7 },
+    // 7 13 3
+    { position: p7, velocity: p13, arm: p3 },
+    // 3 7 18
+    { position: p3, velocity: p7, arm: p18 },
+
+    /// 10th
+    // 6 7 19
+    { position: p6, velocity: p7, arm: p19 },
+    // 6 7 17
+    { position: p6, velocity: p7, arm: p17 },
+    // 7 17 18
+    { position: p7, velocity: p17, arm: p18 },
+
+    /// 11th
+    // 6 19 20
+    { position: p6, velocity: p19, arm: p20 },
+    // 6 10 20
+    { position: p6, velocity: p10, arm: p20 },
+    // 5 10 20
+    { position: p5, velocity: p10, arm: p20 },
+
+    /// 12th
+    // 5 8 20
+    { position: p5, velocity: p8, arm: p20 },
+    // 5 8 16
+    { position: p5, velocity: p8, arm: p16 },
+    // 5 15 16
+    { position: p5, velocity: p15, arm: p16 },
+  ] as Cell[];
+};
+
 // 20 faces, thanks to https://math.stackexchange.com/a/2174924/54238
 let createRegularIcosahedron = () => {
   let sqrt5 = Math.sqrt(5);
@@ -174,7 +305,8 @@ export const surroundMirrorConfigs: SolubleApp = {
     // let items = createCone();
     // let items = createAngle();
     // let items = createRegularIcosahedron();
-    let items = createRegularTetrahedron();
+    // let items = createRegularTetrahedron();
+    let items = createRegularDodecahedron();
 
     createGlobalPointsBuffer(items.length, (idx) => items[idx]);
   },

--- a/src/apps/surround-mirror.mts
+++ b/src/apps/surround-mirror.mts
@@ -12,8 +12,39 @@ let store = {
   startedAt: performance.now(),
 };
 
+let a = 400;
+
+let createCube = () => {
+  let p1 = [-a, -a, a, 0];
+  let p2 = [a, -a, a, 0];
+  let p3 = [a, -a, -a, 0];
+  let p4 = [-a, -a, -a, 0];
+  let p5 = [-a, a, a, 0];
+  let p6 = [a, a, a, 0];
+  let p7 = [a, a, -a, 0];
+  let p8 = [-a, a, -a, 0];
+
+  return [
+    { position: p1, velocity: p2, arm: p3 },
+    { position: p1, velocity: p3, arm: p4 },
+    { position: p1, velocity: p2, arm: p6 },
+    { position: p1, velocity: p5, arm: p6 },
+    { position: p1, velocity: p8, arm: p4 },
+    { position: p1, velocity: p8, arm: p5 },
+    { position: p2, velocity: p7, arm: p3 },
+    { position: p2, velocity: p7, arm: p6 },
+    { position: p3, velocity: p8, arm: p4 },
+    { position: p3, velocity: p8, arm: p7 },
+    { position: p5, velocity: p7, arm: p6 },
+    { position: p5, velocity: p7, arm: p8 },
+  ] as {
+    position: Number4;
+    velocity: Number4;
+    arm: Number4;
+  }[];
+};
+
 let createOctahedron = () => {
-  let a = 400;
   let p1 = [-a, 0, a, 0];
   let p2 = [a, 0, a, 0];
   let p3 = [a, 0, -a, 0];
@@ -39,7 +70,8 @@ let createOctahedron = () => {
 
 export const surroundMirrorConfigs: SolubleApp = {
   initPointsBuffer: () => {
-    let items = createOctahedron();
+    // let items = createOctahedron();
+    let items = createCube();
     createGlobalPointsBuffer(items.length, (idx) => items[idx]);
   },
   useCompute: false,

--- a/src/apps/surround-mirror.mts
+++ b/src/apps/surround-mirror.mts
@@ -102,6 +102,17 @@ let createCone = () => {
   return cells;
 };
 
+let createAwl = () => {
+  let a = 40;
+  let d = 200;
+  let SQRT_3 = Math.sqrt(3);
+  let p0: Number4 = [0, 0, -d, 0];
+  let p1: Number4 = [0, a, d, 0];
+  let p2: Number4 = [a * SQRT_3 * 0.5, -0.5 * a, d, 0];
+  let p3: Number4 = [-a * SQRT_3 * 0.5, -0.5 * a, d, 0];
+  return [makeCell(p0, p1, p2), makeCell(p0, p1, p3), makeCell(p0, p2, p3)] as Cell[];
+};
+
 let createAngle = () => {
   let a = 400;
   let ratio = 0.6;
@@ -299,7 +310,8 @@ export const surroundMirrorConfigs: SolubleApp = {
   initPointsBuffer: () => {
     // let items = createOctahedron();
     // let items = createCube();
-    let items = createCone();
+    // let items = createCone();
+    let items = createAwl();
     // let items = createAngle();
     // let items = createRegularIcosahedron();
     // let items = createRegularTetrahedron();

--- a/src/apps/surround-mirror.wgsl
+++ b/src/apps/surround-mirror.wgsl
@@ -223,7 +223,7 @@ fn fragment_main(vx_out: VertexOut) -> @location(0) vec4<f32> {
   for (var times = 0u; times < max_relect_times + 1u; times++) {
     for (var i = 0u; i < segments_size; i = i + 1u) {
       var segment = segments[i];
-      segment = rotate_segment(segment, vec3(0., 0., 0.), vec3(0., 1., 0.), params.time * 0.0004);
+      segment = rotate_segment(segment, vec3(0., 0., 0.), vec3(0., 1., 0.), params.time * 0.0008);
       let reach = ray_closest_point_to_line(current_viewer, current_ray_unit, segment);
 
       if reach.positive_side {
@@ -256,7 +256,7 @@ fn fragment_main(vx_out: VertexOut) -> @location(0) vec4<f32> {
     }
 
     if hit_mirror {
-      total_color += vec4<f32>(0.02, 0.02, .04, 0.);
+      total_color += vec4<f32>(0.01, 0.01, .02, 0.);
       current_viewer = nearest.point;
       current_ray_unit = nearest.next_ray_unit;
     } else {

--- a/src/apps/surround-mirror.wgsl
+++ b/src/apps/surround-mirror.wgsl
@@ -225,10 +225,10 @@ fn fragment_main(vx_out: VertexOut) -> @location(0) vec4<f32> {
       if reach.positive_side {
         let distance = reach.distance;
         // let factor = (0.1 + exp(-traveled));
-        if distance < 0.08 * (1. + pow(traveled * 0.3, 0.8)) && reach.positive_side {
-          return vec4<f32>(1.0, 0.8, 0.0, 1.0);
-        }
-        total_color += vec4<f32>(1., 1., 0.02, 0.0) / pow(distance, 1.8);
+        // if distance < 0.08 * (1. + pow(traveled * 0.3, 0.8)) && reach.positive_side {
+        //   return vec4<f32>(1.0, 0.8, 0.0, 1.0);
+        // }
+        total_color += vec4<f32>(1., 1., 0.02, 0.0) * 2. / pow(distance, 1.8);
       }
     }
 
@@ -252,7 +252,7 @@ fn fragment_main(vx_out: VertexOut) -> @location(0) vec4<f32> {
     }
 
     if hit_mirror {
-      total_color += vec4<f32>(0.01, 0.01, .02, 0.);
+      total_color += vec4<f32>(0.02, 0.01, .04, 0.) ;
       current_viewer = nearest.point;
       current_ray_unit = nearest.next_ray_unit;
     } else {

--- a/src/apps/surround-mirror.wgsl
+++ b/src/apps/surround-mirror.wgsl
@@ -183,7 +183,7 @@ fn fragment_main(vx_out: VertexOut) -> @location(0) vec4<f32> {
   let image_y = vec3f(0., 1., 0.);
   let image_x = rotate_vec3(vec3f(1., 0., 0.), image_center, image_y, angle);
   let image_z = rotate_vec3(vec3f(0., 0., 1.), image_center, image_y, angle);
-  let image_radius = 120.0; // but rect
+  let image_radius = 160.0; // but rect
 
 
   var current_viewer = uniforms.viewer_position;

--- a/src/apps/surround-mirror.wgsl
+++ b/src/apps/surround-mirror.wgsl
@@ -1,0 +1,155 @@
+
+#import soluble::perspective
+
+#import soluble::math
+
+struct Params {
+  time: f32,
+  dt: f32,
+  /// 1 to disable
+  disableLens: f32,
+  maskRadius: f32,
+}
+
+@group(0) @binding(1) var<uniform> params: Params;
+
+
+
+struct BaseCell {
+  position: vec4<f32>,
+  arm: vec4<f32>,
+  // offset
+  idx: f32,
+  offset: f32,
+  // duration
+  duration: f32,
+  time: f32,
+};
+
+@group(1) @binding(0) var<storage, read_write> base_points: array<BaseCell>;
+
+
+@compute @workgroup_size(8, 8, 1)
+fn compute_main(@builtin(global_invocation_id) global_id: vec3u) {
+  // not doint things
+}
+
+// shapes
+
+fn reflection_line(p: vec2f, p1: vec2f, p2: vec2f, skip: f32, regress: f32) -> vec2f {
+  let perp = perpendicular(p, p1, p2);
+  let d = perp - p;
+  let ld = length(d);
+  return perp + (d + (-skip * d / ld)) * regress;
+}
+
+
+/// reflect line A upon the part that is parrallel to B
+fn reflect_on_direction(a: vec3<f32>, b: vec3<f32>) -> vec3<f32> {
+  let b0 = normalize(b);
+  let v_ = dot(a, b0) * b0;
+  let v_p = a - v_;
+  return v_ - v_p;
+}
+
+/// result holding information how ray is close to segment line
+struct RayReachSegment {
+  distance: f32,
+  point: vec3<f32>,
+}
+
+
+struct Segment {
+  start: vec3<f32>,
+  end: vec3<f32>,
+}
+
+/// find out closest point of ray to the segment
+fn ray_closest_point_to_line(ray_unit: vec3f, s: Segment, viewer_position: vec3f) -> RayReachSegment {
+  let a = s.start - viewer_position;
+  let b = s.end - viewer_position;
+
+  // find perp direction and projection length on it
+  let n = cross(b - a, ray_unit);
+
+  let n0 = normalize(n);
+
+  /// smaller distance to segments ends
+  let d_min = min(abs(dot(n0, a)), abs(dot(n0, b)));
+
+  // find projection of a of segment on ray direction, and use the Pythagorean theorem for another distance
+  let a_proj = dot(ray_unit, a);
+  let a_proj_at = ray_unit * a_proj;
+  let shadow_a = a - a_proj_at;
+
+  let b_proj = dot(ray_unit, b);
+  let b_proj_at = ray_unit * b_proj;
+  let shadow_b = b - b_proj_at;
+
+  let direct_an = cross(shadow_a, n);
+  let direct_bn = cross(shadow_b, n);
+      // a and b on the same side of N
+  let same_side = dot(direct_an, direct_bn) >= 0.0;
+
+  var nearest: f32;
+  if same_side {
+    let a_distance_min = sqrt(dot(a, a) - a_proj * a_proj);
+    let b_distance_min = sqrt(dot(b, b) - b_proj * b_proj);
+    nearest = min(a_distance_min, b_distance_min);
+  } else {
+    nearest = d_min;
+  };
+
+  return RayReachSegment(nearest, viewer_position + ray_unit * a_proj);
+}
+
+// Render Pass
+
+struct VertexOut {
+  @builtin(position) position: vec4<f32>,
+  @location(1) uv: vec2<f32>,
+};
+
+@vertex
+fn vertex_main(
+  @location(0) position: vec2<f32>,
+) -> VertexOut {
+  var output: VertexOut;
+  output.position = vec4(position, 0.0, 1.0);
+  output.uv = vec2<f32>(position.x, position.y);
+  return output;
+}
+
+@fragment
+fn fragment_main(vx_out: VertexOut) -> @location(0) vec4<f32> {
+
+  // pixel coordinates
+  let coord: vec2<f32> = vx_out.uv * uniforms.screen_wh;
+  let p: vec2<f32> = coord * 0.0005 / uniforms.scale;
+
+  // var base_size = arrayLength(&base_points);
+  let segments = array<Segment, 2>(
+    Segment(vec3<f32>(0.0, 0.0, 0.0), vec3<f32>(20.0, 100.0, 0.0)),
+    Segment(vec3<f32>(0.0, 0.0, 0.0), vec3<f32>(-20.0, 100.0, 0.0))
+  );
+
+  // create view ray
+  let ray_unit = normalize(
+    p.x * uniforms.rightward + p.y * uniforms.upward + 2.0 * uniforms.forward
+  );
+
+  for (var i = 0u; i < 2u; i = i + 1u) {
+    let segment = segments[i];
+    let reach = ray_closest_point_to_line(ray_unit, segment, uniforms.viewer_position);
+    let distance = reach.distance;
+    // let point = reach.point;
+
+    if distance < 1.0 {
+      return vec4<f32>(1.0, 0.0, 0.0, 1.0);
+    }
+  }
+
+
+
+  return vec4<f32>(0.2, 0.0, 0.3, 1.0);
+}

--- a/src/apps/surround-mirror.wgsl
+++ b/src/apps/surround-mirror.wgsl
@@ -52,7 +52,6 @@ struct Segment {
 }
 
 /// find out closest point of ray to the segment
-/// TODO remove hits behind the camera
 fn ray_closest_point_to_line(viewer_position: vec3f, ray_unit: vec3f, s: Segment) -> RayReachSegment {
   let a = s.start - viewer_position;
   let b = s.end - viewer_position;

--- a/src/math.mts
+++ b/src/math.mts
@@ -26,6 +26,10 @@ export let rand = (n: number) => {
   return (Math.random() - 0.5) * n;
 };
 
+export let randBetween = (min: number, max: number) => {
+  return Math.random() * (max - min) + min;
+};
+
 export const randBalance = (max: number) => {
   return Math.floor(Math.random() * max) - max / 2;
 };

--- a/src/math.mts
+++ b/src/math.mts
@@ -35,6 +35,7 @@ export const randBalance = (max: number) => {
 };
 
 export type Number4 = [number, number, number, number];
+export type Number2 = [number, number];
 
 export let normalize = (v: V4): V4 => {
   let len = Math.sqrt(sumSquares(v[0], v[1], v[2]));

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@calcit/procs@^0.8.50":
-  version "0.8.50"
-  resolved "https://registry.yarnpkg.com/@calcit/procs/-/procs-0.8.50.tgz#64466bc233297b195297eb4e5be5fc82215fe277"
-  integrity sha512-tU3u0uCmBmagU5ZDmjwud2MwGlWE7QL2fRAbzAuaZE+5G4rA2MrZcnZNIOJYeiJkd90fQV1c67EkqFWplGWKSw==
+"@calcit/procs@^0.8.54":
+  version "0.8.54"
+  resolved "https://registry.yarnpkg.com/@calcit/procs/-/procs-0.8.54.tgz#aa62a5eebf30393f60e4217d6b81fdddf1c084f5"
+  integrity sha512-pHbaRVBK+ncDxrqH4iNyWbJxGxJd0hlRMJ6YtcYiJWbHcdCA6SBnFprXORvG0bJ8rfUOu3bZSSGvfvl83zpa1Q==
   dependencies:
     "@calcit/ternary-tree" "0.0.24"
     "@cirru/parser.ts" "^0.0.6"
@@ -150,80 +150,85 @@
     estree-walker "^2.0.2"
     picomatch "^2.3.1"
 
-"@rollup/rollup-android-arm-eabi@4.14.2":
-  version "4.14.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.14.2.tgz#9047b5b1ec19f58c0fdf3a072bd977bcec056576"
-  integrity sha512-ahxSgCkAEk+P/AVO0vYr7DxOD3CwAQrT0Go9BJyGQ9Ef0QxVOfjDZMiF4Y2s3mLyPrjonchIMH/tbWHucJMykQ==
+"@rollup/rollup-android-arm-eabi@4.18.0":
+  version "4.18.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.18.0.tgz#bbd0e616b2078cd2d68afc9824d1fadb2f2ffd27"
+  integrity sha512-Tya6xypR10giZV1XzxmH5wr25VcZSncG0pZIjfePT0OVBvqNEurzValetGNarVrGiq66EBVAFn15iYX4w6FKgQ==
 
-"@rollup/rollup-android-arm64@4.14.2":
-  version "4.14.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.14.2.tgz#08a2d2705193ebb3054941994e152808beb5254e"
-  integrity sha512-lAarIdxZWbFSHFSDao9+I/F5jDaKyCqAPMq5HqnfpBw8dKDiCaaqM0lq5h1pQTLeIqueeay4PieGR5jGZMWprw==
+"@rollup/rollup-android-arm64@4.18.0":
+  version "4.18.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.18.0.tgz#97255ef6384c5f73f4800c0de91f5f6518e21203"
+  integrity sha512-avCea0RAP03lTsDhEyfy+hpfr85KfyTctMADqHVhLAF3MlIkq83CP8UfAHUssgXTYd+6er6PaAhx/QGv4L1EiA==
 
-"@rollup/rollup-darwin-arm64@4.14.2":
-  version "4.14.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.14.2.tgz#bf746c610f337b104408ec001549d825a91eca57"
-  integrity sha512-SWsr8zEUk82KSqquIMgZEg2GE5mCSfr9sE/thDROkX6pb3QQWPp8Vw8zOq2GyxZ2t0XoSIUlvHDkrf5Gmf7x3Q==
+"@rollup/rollup-darwin-arm64@4.18.0":
+  version "4.18.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.18.0.tgz#b6dd74e117510dfe94541646067b0545b42ff096"
+  integrity sha512-IWfdwU7KDSm07Ty0PuA/W2JYoZ4iTj3TUQjkVsO/6U+4I1jN5lcR71ZEvRh52sDOERdnNhhHU57UITXz5jC1/w==
 
-"@rollup/rollup-darwin-x64@4.14.2":
-  version "4.14.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.14.2.tgz#59ebe3b858a44680d5f87546ea2df1c7e3135f6a"
-  integrity sha512-o/HAIrQq0jIxJAhgtIvV5FWviYK4WB0WwV91SLUnsliw1lSAoLsmgEEgRWzDguAFeUEUUoIWXiJrPqU7vGiVkA==
+"@rollup/rollup-darwin-x64@4.18.0":
+  version "4.18.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.18.0.tgz#e07d76de1cec987673e7f3d48ccb8e106d42c05c"
+  integrity sha512-n2LMsUz7Ynu7DoQrSQkBf8iNrjOGyPLrdSg802vk6XT3FtsgX6JbE8IHRvposskFm9SNxzkLYGSq9QdpLYpRNA==
 
-"@rollup/rollup-linux-arm-gnueabihf@4.14.2":
-  version "4.14.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.14.2.tgz#44cffc07d04d659cb635aec11bef530d5757ee6a"
-  integrity sha512-nwlJ65UY9eGq91cBi6VyDfArUJSKOYt5dJQBq8xyLhvS23qO+4Nr/RreibFHjP6t+5ap2ohZrUJcHv5zk5ju/g==
+"@rollup/rollup-linux-arm-gnueabihf@4.18.0":
+  version "4.18.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.18.0.tgz#9f1a6d218b560c9d75185af4b8bb42f9f24736b8"
+  integrity sha512-C/zbRYRXFjWvz9Z4haRxcTdnkPt1BtCkz+7RtBSuNmKzMzp3ZxdM28Mpccn6pt28/UWUCTXa+b0Mx1k3g6NOMA==
 
-"@rollup/rollup-linux-arm64-gnu@4.14.2":
-  version "4.14.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.14.2.tgz#9901e2288fb192b74a2f8428c507d43cc2739ceb"
-  integrity sha512-Pg5TxxO2IVlMj79+c/9G0LREC9SY3HM+pfAwX7zj5/cAuwrbfj2Wv9JbMHIdPCfQpYsI4g9mE+2Bw/3aeSs2rQ==
+"@rollup/rollup-linux-arm-musleabihf@4.18.0":
+  version "4.18.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.18.0.tgz#53618b92e6ffb642c7b620e6e528446511330549"
+  integrity sha512-l3m9ewPgjQSXrUMHg93vt0hYCGnrMOcUpTz6FLtbwljo2HluS4zTXFy2571YQbisTnfTKPZ01u/ukJdQTLGh9A==
 
-"@rollup/rollup-linux-arm64-musl@4.14.2":
-  version "4.14.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.14.2.tgz#8a2c55a72e0c716a15d830fee3bf5a1a756f13ec"
-  integrity sha512-cAOTjGNm84gc6tS02D1EXtG7tDRsVSDTBVXOLbj31DkwfZwgTPYZ6aafSU7rD/4R2a34JOwlF9fQayuTSkoclA==
+"@rollup/rollup-linux-arm64-gnu@4.18.0":
+  version "4.18.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.18.0.tgz#99a7ba5e719d4f053761a698f7b52291cefba577"
+  integrity sha512-rJ5D47d8WD7J+7STKdCUAgmQk49xuFrRi9pZkWoRD1UeSMakbcepWXPF8ycChBoAqs1pb2wzvbY6Q33WmN2ftw==
 
-"@rollup/rollup-linux-powerpc64le-gnu@4.14.2":
-  version "4.14.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.14.2.tgz#71bf99c8017476ac85b09d21b3fa2eacbad96100"
-  integrity sha512-4RyT6v1kXb7C0fn6zV33rvaX05P0zHoNzaXI/5oFHklfKm602j+N4mn2YvoezQViRLPnxP8M1NaY4s/5kXO5cw==
+"@rollup/rollup-linux-arm64-musl@4.18.0":
+  version "4.18.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.18.0.tgz#f53db99a45d9bc00ce94db8a35efa7c3c144a58c"
+  integrity sha512-be6Yx37b24ZwxQ+wOQXXLZqpq4jTckJhtGlWGZs68TgdKXJgw54lUUoFYrg6Zs/kjzAQwEwYbp8JxZVzZLRepQ==
 
-"@rollup/rollup-linux-riscv64-gnu@4.14.2":
-  version "4.14.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.14.2.tgz#48ee7fe5fee7b6d0028b6dda4fab95238208a0cd"
-  integrity sha512-KNUH6jC/vRGAKSorySTyc/yRYlCwN/5pnMjXylfBniwtJx5O7X17KG/0efj8XM3TZU7raYRXJFFReOzNmL1n1w==
+"@rollup/rollup-linux-powerpc64le-gnu@4.18.0":
+  version "4.18.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.18.0.tgz#cbb0837408fe081ce3435cf3730e090febafc9bf"
+  integrity sha512-hNVMQK+qrA9Todu9+wqrXOHxFiD5YmdEi3paj6vP02Kx1hjd2LLYR2eaN7DsEshg09+9uzWi2W18MJDlG0cxJA==
 
-"@rollup/rollup-linux-s390x-gnu@4.14.2":
-  version "4.14.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.14.2.tgz#65ad6f82729ef9d8634847189214e3205892f42f"
-  integrity sha512-xPV4y73IBEXToNPa3h5lbgXOi/v0NcvKxU0xejiFw6DtIYQqOTMhZ2DN18/HrrP0PmiL3rGtRG9gz1QE8vFKXQ==
+"@rollup/rollup-linux-riscv64-gnu@4.18.0":
+  version "4.18.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.18.0.tgz#8ed09c1d1262ada4c38d791a28ae0fea28b80cc9"
+  integrity sha512-ROCM7i+m1NfdrsmvwSzoxp9HFtmKGHEqu5NNDiZWQtXLA8S5HBCkVvKAxJ8U+CVctHwV2Gb5VUaK7UAkzhDjlg==
 
-"@rollup/rollup-linux-x64-gnu@4.14.2":
-  version "4.14.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.14.2.tgz#2ab802ce25c0d0d44a0ea55b0068f79e462d22cd"
-  integrity sha512-QBhtr07iFGmF9egrPOWyO5wciwgtzKkYPNLVCFZTmr4TWmY0oY2Dm/bmhHjKRwZoGiaKdNcKhFtUMBKvlchH+Q==
+"@rollup/rollup-linux-s390x-gnu@4.18.0":
+  version "4.18.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.18.0.tgz#938138d3c8e0c96f022252a28441dcfb17afd7ec"
+  integrity sha512-0UyyRHyDN42QL+NbqevXIIUnKA47A+45WyasO+y2bGJ1mhQrfrtXUpTxCOrfxCR4esV3/RLYyucGVPiUsO8xjg==
 
-"@rollup/rollup-linux-x64-musl@4.14.2":
-  version "4.14.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.14.2.tgz#85dcd3f549c2fdbcf1cb1f1b5f501933ed590880"
-  integrity sha512-8zfsQRQGH23O6qazZSFY5jP5gt4cFvRuKTpuBsC1ZnSWxV8ZKQpPqOZIUtdfMOugCcBvFGRa1pDC/tkf19EgBw==
+"@rollup/rollup-linux-x64-gnu@4.18.0":
+  version "4.18.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.18.0.tgz#1a7481137a54740bee1ded4ae5752450f155d942"
+  integrity sha512-xuglR2rBVHA5UsI8h8UbX4VJ470PtGCf5Vpswh7p2ukaqBGFTnsfzxUBetoWBWymHMxbIG0Cmx7Y9qDZzr648w==
 
-"@rollup/rollup-win32-arm64-msvc@4.14.2":
-  version "4.14.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.14.2.tgz#10f608dfc1e5bb96aca18c7784cc4a94d890c03c"
-  integrity sha512-H4s8UjgkPnlChl6JF5empNvFHp77Jx+Wfy2EtmYPe9G22XV+PMuCinZVHurNe8ggtwoaohxARJZbaH/3xjB/FA==
+"@rollup/rollup-linux-x64-musl@4.18.0":
+  version "4.18.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.18.0.tgz#f1186afc601ac4f4fc25fac4ca15ecbee3a1874d"
+  integrity sha512-LKaqQL9osY/ir2geuLVvRRs+utWUNilzdE90TpyoX0eNqPzWjRm14oMEE+YLve4k/NAqCdPkGYDaDF5Sw+xBfg==
 
-"@rollup/rollup-win32-ia32-msvc@4.14.2":
-  version "4.14.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.14.2.tgz#f27f9fb64b7e10b04121e0054d9145ee21589267"
-  integrity sha512-djqpAjm/i8erWYF0K6UY4kRO3X5+T4TypIqw60Q8MTqSBaQNpNXDhxdjpZ3ikgb+wn99svA7jxcXpiyg9MUsdw==
+"@rollup/rollup-win32-arm64-msvc@4.18.0":
+  version "4.18.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.18.0.tgz#ed6603e93636a96203c6915be4117245c1bd2daf"
+  integrity sha512-7J6TkZQFGo9qBKH0pk2cEVSRhJbL6MtfWxth7Y5YmZs57Pi+4x6c2dStAUvaQkHQLnEQv1jzBUW43GvZW8OFqA==
 
-"@rollup/rollup-win32-x64-msvc@4.14.2":
-  version "4.14.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.14.2.tgz#5d2d9dc96b436469dc74ef93de069b14fb12aace"
-  integrity sha512-teAqzLT0yTYZa8ZP7zhFKEx4cotS8Tkk5XiqNMJhD4CpaWB1BHARE4Qy+RzwnXvSAYv+Q3jAqCVBS+PS+Yee8Q==
+"@rollup/rollup-win32-ia32-msvc@4.18.0":
+  version "4.18.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.18.0.tgz#14e0b404b1c25ebe6157a15edb9c46959ba74c54"
+  integrity sha512-Txjh+IxBPbkUB9+SXZMpv+b/vnTEtFyfWZgJ6iyCmt2tdx0OF5WhFowLmnh8ENGNpfUlUZkdI//4IEmhwPieNg==
+
+"@rollup/rollup-win32-x64-msvc@4.18.0":
+  version "4.18.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.18.0.tgz#5d694d345ce36b6ecf657349e03eb87297e68da4"
+  integrity sha512-UOo5FdvOL0+eIVTgS4tIdbW+TtnBLWg1YBCcU2KWM7nuNwRz9bksDX1bekJJCpu25N1DVWaCwnT39dVQxzqS8g==
 
 "@triadica/touch-control@^0.0.4-a1":
   version "0.0.4-a1"
@@ -235,10 +240,10 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.5.tgz#a6ce3e556e00fd9895dd872dd172ad0d4bd687f4"
   integrity sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==
 
-"@types/node@^20.12.7":
-  version "20.12.7"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.12.7.tgz#04080362fa3dd6c5822061aa3124f5c152cff384"
-  integrity sha512-wq0cICSkRLVaf3UGLMGItu/PtdY7oaXaI/RVU+xliKVOtRna3PRY57ZDfztpDL0n11vfymMUnXv8QwYCO7L1wg==
+"@types/node@^20.12.12":
+  version "20.12.12"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.12.12.tgz#7cbecdf902085cec634fdb362172dfe12b8f2050"
+  integrity sha512-eWLDGF/FOSPtAvEqeRAQ4C8LSA7M1I7i0ky1I8U7kD1J5ITyW3AsRhQrKVoWf5pFKZ2kILsEGJhsI9r93PYnOw==
   dependencies:
     undici-types "~5.26.4"
 
@@ -386,9 +391,9 @@ next-tick@^0.2.2:
   integrity sha512-f7h4svPtl+QidoBv4taKXUjJ70G2asaZ8G28nS0OkqaalX8dwwrtWtyxEDPK62AC00ur/+/E0pUwBwY5EPn15Q==
 
 picocolors@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
-  integrity sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.1.tgz#a8ad579b571952f0e5d25892de5445bcfe25aaa1"
+  integrity sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==
 
 picomatch@^2.3.1:
   version "2.3.1"
@@ -424,27 +429,28 @@ query-string@^9.0.0:
     split-on-first "^3.0.0"
 
 rollup@^4.13.0:
-  version "4.14.2"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-4.14.2.tgz#992df3c3bb4ca84ce6b00d51aacb1e5a62d0a14c"
-  integrity sha512-WkeoTWvuBoFjFAhsEOHKRoZ3r9GfTyhh7Vff1zwebEFLEFjT1lG3784xEgKiTa7E+e70vsC81roVL2MP4tgEEQ==
+  version "4.18.0"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-4.18.0.tgz#497f60f0c5308e4602cf41136339fbf87d5f5dda"
+  integrity sha512-QmJz14PX3rzbJCN1SG4Xe/bAAX2a6NpCP8ab2vfu2GiUr8AQcr2nCV/oEO3yneFarB67zk8ShlIyWb2LGTb3Sg==
   dependencies:
     "@types/estree" "1.0.5"
   optionalDependencies:
-    "@rollup/rollup-android-arm-eabi" "4.14.2"
-    "@rollup/rollup-android-arm64" "4.14.2"
-    "@rollup/rollup-darwin-arm64" "4.14.2"
-    "@rollup/rollup-darwin-x64" "4.14.2"
-    "@rollup/rollup-linux-arm-gnueabihf" "4.14.2"
-    "@rollup/rollup-linux-arm64-gnu" "4.14.2"
-    "@rollup/rollup-linux-arm64-musl" "4.14.2"
-    "@rollup/rollup-linux-powerpc64le-gnu" "4.14.2"
-    "@rollup/rollup-linux-riscv64-gnu" "4.14.2"
-    "@rollup/rollup-linux-s390x-gnu" "4.14.2"
-    "@rollup/rollup-linux-x64-gnu" "4.14.2"
-    "@rollup/rollup-linux-x64-musl" "4.14.2"
-    "@rollup/rollup-win32-arm64-msvc" "4.14.2"
-    "@rollup/rollup-win32-ia32-msvc" "4.14.2"
-    "@rollup/rollup-win32-x64-msvc" "4.14.2"
+    "@rollup/rollup-android-arm-eabi" "4.18.0"
+    "@rollup/rollup-android-arm64" "4.18.0"
+    "@rollup/rollup-darwin-arm64" "4.18.0"
+    "@rollup/rollup-darwin-x64" "4.18.0"
+    "@rollup/rollup-linux-arm-gnueabihf" "4.18.0"
+    "@rollup/rollup-linux-arm-musleabihf" "4.18.0"
+    "@rollup/rollup-linux-arm64-gnu" "4.18.0"
+    "@rollup/rollup-linux-arm64-musl" "4.18.0"
+    "@rollup/rollup-linux-powerpc64le-gnu" "4.18.0"
+    "@rollup/rollup-linux-riscv64-gnu" "4.18.0"
+    "@rollup/rollup-linux-s390x-gnu" "4.18.0"
+    "@rollup/rollup-linux-x64-gnu" "4.18.0"
+    "@rollup/rollup-linux-x64-musl" "4.18.0"
+    "@rollup/rollup-win32-arm64-msvc" "4.18.0"
+    "@rollup/rollup-win32-ia32-msvc" "4.18.0"
+    "@rollup/rollup-win32-x64-msvc" "4.18.0"
     fsevents "~2.3.2"
 
 source-map-js@^1.2.0:
@@ -493,10 +499,10 @@ vite-plugin-glsl@^1.3.0:
   dependencies:
     "@rollup/pluginutils" "^5.1.0"
 
-vite@^5.2.8:
-  version "5.2.8"
-  resolved "https://registry.yarnpkg.com/vite/-/vite-5.2.8.tgz#a99e09939f1a502992381395ce93efa40a2844aa"
-  integrity sha512-OyZR+c1CE8yeHw5V5t59aXsUPPVTHMDjEZz8MgguLL/Q7NblxhZUlTu9xSPqlsUO/y+X7dlU05jdhvyycD55DA==
+vite@^5.2.11:
+  version "5.2.11"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-5.2.11.tgz#726ec05555431735853417c3c0bfb36003ca0cbd"
+  integrity sha512-HndV31LWW05i1BLPMUCE1B9E9GFbOu1MbenhS58FuK6owSO5qHm7GiCotrNY1YE5rMeQSFBGmT5ZaLEjFizgiQ==
   dependencies:
     esbuild "^0.20.1"
     postcss "^8.4.38"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@calcit/procs@^0.8.54":
-  version "0.8.54"
-  resolved "https://registry.yarnpkg.com/@calcit/procs/-/procs-0.8.54.tgz#aa62a5eebf30393f60e4217d6b81fdddf1c084f5"
-  integrity sha512-pHbaRVBK+ncDxrqH4iNyWbJxGxJd0hlRMJ6YtcYiJWbHcdCA6SBnFprXORvG0bJ8rfUOu3bZSSGvfvl83zpa1Q==
+"@calcit/procs@^0.8.55":
+  version "0.8.55"
+  resolved "https://registry.yarnpkg.com/@calcit/procs/-/procs-0.8.55.tgz#2730f936dca29ea73247c581429206362c1d08b9"
+  integrity sha512-5P+gG4xgxaAzOPo385K+V/C99HwCura8NBkKO9upXLld130XfsticbINzC6NR2F5mrFY2y5EbQb+Hrbl3Ed1Ww==
   dependencies:
     "@calcit/ternary-tree" "0.0.24"
     "@cirru/parser.ts" "^0.0.6"


### PR DESCRIPTION
new images are cropped from Pinterest.

<img width="1341" alt="image" src="https://github.com/Triadica/soluble/assets/449224/9619f7f6-b1c7-4887-9cb6-1346f7cfd9be">

<img width="1240" alt="image" src="https://github.com/Triadica/soluble/assets/449224/4fb69b0a-d243-426a-82ec-8fcd067a7482">
<img width="1134" alt="image" src="https://github.com/Triadica/soluble/assets/449224/3eda40f7-4390-41ab-9bfe-2acb7bd365d9">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced new textures: "pigment" and "stripes" for enhanced visual effects.
  - Added new geometric shapes and mirror effects in the 3D rendering engine.
  - Implemented parallel and surround mirror effects for advanced visual simulations.

- **Updates**
  - Updated dependencies to the latest versions for improved stability and performance.
  - Enhanced the kaleidoscope effect by increasing the iteration count for finer detail.

- **Improvements**
  - Improved ray reflection calculations in shaders for more accurate visual effects.
  - Added new utility functions for random number generation and vector rotation in shaders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->